### PR TITLE
Fix issue in Chrome. Build debug versions and production versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ elm-stuff
 # elm-repl generated files
 repl-temp-*
 
-# Dependency directories
+# Dependency directories & files
+yarn-error.log
 node_modules
 
 # Desktop Services Store on macOS

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/config/webpack.config.debug.js
+++ b/config/webpack.config.debug.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const paths = require('../config/paths');
+const prodConfig = require('./webpack.config.prod.js');
+
+module.exports = function () {
+    let config = prodConfig();
+
+    config.entry = {
+        "componentLib.debug": paths.componentLibJs,
+        "coordinatorLib.debug": paths.coordinatorLibJs
+    };
+
+    config.module.rules = config.module.rules.map((rule) => {
+        if (rule.use && rule.use[0] && rule.use[0].pathToMake == paths.elmMake) {
+            rule.use[0].debug = true;
+        }
+        return rule;
+    });
+
+    return config;
+
+};

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -6,7 +6,8 @@ const paths = require('../config/paths');
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
 
-module.exports = {
+module.exports = function () {
+    return {
   // Don't attempt to continue if there are any errors.
   bail: true,
 
@@ -113,4 +114,5 @@ module.exports = {
     tls: 'empty',
     child_process: 'empty'
   }
+    };
 };

--- a/src/elements/component-frame.js
+++ b/src/elements/component-frame.js
@@ -9,11 +9,17 @@ export default class ComponentFrame extends HTMLElement {
 
     constructor() {
         super();
+
         this.iframe = document.createElement('iframe');
         this.iframe.setAttribute('frameborder', 0);
         this.iframe.setAttribute('style', IFRAME_STYLE);
         this.iframe.setAttribute('sandbox', 'allow-scripts');
-        this.appendChild(this.iframe);
+    }
+
+    connectedCallback() {
+        if (this.children[0] != this.iframe) {
+            this.appendChild(this.iframe);
+        }
     }
 
     attributeChangedCallback(name, oldValue, newValue) {


### PR DESCRIPTION
The custom element API spec doesn't allow modification of the DOM in the element constructor. I missed that detail, and the polyfill can't enforce that check, so things were blowing up in chrome. This fixes that issue.

Additionally, the build scripts are further improved to generate js files with the Elm debugger enabled, which are helpful for testing when embedding in other apps. 

@xdumaine @justinaray @jrrucker @JackieChiles @omarestrella @bjdupuis