### PR TITLE
Fast-fail buildall script

### DIFF
--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 PROJ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
 


### PR DESCRIPTION
Set -e option to fail the build on elm compilation errors.  Otherwise, the demo app starts unconditionally.