### PR TITLE
Strip host route from client path before navigating client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ host.registerElements();
  * path for that client. `url` is the page to load in the
  * iframe on that route. So in this example, the fragment
  * `#/one/my/path` would cause the `frame-router` element
- * to display the iframe at `//component/example1/#/one/my/path`
+ * to display the iframe at `//component/example1/#/my/path`
  */
 document.getElementById("frame-element").registerClients({
   client1: {

--- a/src/Path.elm
+++ b/src/Path.elm
@@ -1,10 +1,11 @@
-module Path exposing (Path, asString, decoder, join, parse, startsWith)
+module Path exposing (Path, asString, decoder, join, parse, startsWith, stripPrefix)
 
 {-| The Path module provides utilities for working with URL paths in the context of the iframe-coordinator.
 -}
 
 import Json.Decode as Decode exposing (Decoder)
 import List.Extra as ListEx
+
 
 
 -- Exports
@@ -41,6 +42,14 @@ startsWith prefixPath path =
     case ( prefixPath, path ) of
         ( Absolute prefixSegments, Absolute segments ) ->
             ListEx.isPrefixOf prefixSegments segments
+
+
+stripPrefix : Path -> Path -> Maybe Path
+stripPrefix prefixPath path =
+    case ( prefixPath, path ) of
+        ( Absolute prefixSegments, Absolute segments ) ->
+            ListEx.stripPrefix prefixSegments segments
+                |> Maybe.map Absolute
 
 
 decoder : Decoder Path


### PR DESCRIPTION
Devs who want the previous behavior can include the same prefix
as part of the client's url hash as in the route.