### PR TITLE
Versioning test v2 - DO NOT MERGE

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,33 +1,33 @@
 {
-  "type": "package",
-  "name": "MattCheely/tryframe-coordinator",
-  "summary": "Tools for coordinating embedded apps via iframes.",
-  "license": "MIT",
-  "version": "1.0.0",
-  "exposed-modules": [
-    "Message.AppToClient",
-    "Message.AppToHost",
-    "Message.ClientToApp",
-    "Message.ClientToHost",
-    "Message.HostToApp",
-    "Message.HostToClient",
-    "Message.Navigation",
-    "Message.PubSub",
-    "Message.Toast",
-    "ClientProgram",
-    "HostProgram"
-  ],
-  "elm-version": "0.19.0 <= v < 0.20.0",
-  "dependencies": {
-    "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
-    "elm/browser": "1.0.0 <= v < 2.0.0",
-    "elm/core": "1.0.0 <= v < 2.0.0",
-    "elm/html": "1.0.0 <= v < 2.0.0",
-    "elm/json": "1.0.0 <= v < 2.0.0",
-    "elm/url": "1.0.0 <= v < 2.0.0",
-    "elm-community/list-extra": "8.0.0 <= v < 9.0.0"
-  },
-  "test-dependencies": {
-    "elm-explorations/test": "1.1.0 <= v < 2.0.0"
-  }
+    "type": "package",
+    "name": "MattCheely/tryframe-coordinator",
+    "summary": "Tools for coordinating embedded apps via iframes.",
+    "license": "MIT",
+    "version": "2.0.0",
+    "exposed-modules": [
+        "Message.AppToClient",
+        "Message.AppToHost",
+        "Message.ClientToApp",
+        "Message.ClientToHost",
+        "Message.HostToApp",
+        "Message.HostToClient",
+        "Message.Navigation",
+        "Message.PubSub",
+        "Message.Toast",
+        "ClientProgram",
+        "HostProgram"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "NoRedInk/elm-json-decode-pipeline": "1.0.0 <= v < 2.0.0",
+        "elm/browser": "1.0.0 <= v < 2.0.0",
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0",
+        "elm-community/list-extra": "8.0.0 <= v < 9.0.0"
+    },
+    "test-dependencies": {
+        "elm-explorations/test": "1.1.0 <= v < 2.0.0"
+    }
 }

--- a/elm.json
+++ b/elm.json
@@ -1,6 +1,6 @@
 {
   "type": "package",
-  "name": "purecloudlabs/iframe-coordinator",
+  "name": "MattCheely/tryframe-coordinator",
   "summary": "Tools for coordinating embedded apps via iframes.",
   "license": "MIT",
   "version": "1.0.0",

--- a/tests/Fixture/ToastMessage.elm
+++ b/tests/Fixture/ToastMessage.elm
@@ -1,13 +1,51 @@
-module Fixture.ToastMessage exposing (toastFuzzer)
+module Fixture.ToastMessage exposing (encodeV1, toastFuzzer, v1Fuzzer)
 
 import Fuzz exposing (Fuzzer, int, list, string)
+import Json.Decode as Decode
 import Json.Encode as Encode
+import LabeledMessage exposing (withLabel)
 import Message.Toast exposing (Toast)
 
 
 toastFuzzer : Fuzzer Toast
 toastFuzzer =
-    Fuzz.map3 Toast
+    Fuzz.map4 Toast
+        Fuzz.string
+        Fuzz.string
+        (Fuzz.maybe (Fuzz.constant Encode.null))
+        (Fuzz.oneOf
+            [ Fuzz.constant "info"
+            , Fuzz.constant "warning"
+            , Fuzz.constant "error"
+            ]
+        )
+
+
+
+-- Old Versions
+
+
+type alias ToastV1 =
+    { title : Maybe String
+    , message : String
+    , custom : Maybe Decode.Value
+    }
+
+
+v1Fuzzer : Fuzzer ToastV1
+v1Fuzzer =
+    Fuzz.map3 ToastV1
         (Fuzz.maybe Fuzz.string)
         Fuzz.string
         (Fuzz.maybe (Fuzz.constant Encode.null))
+
+
+encodeV1 : ToastV1 -> Encode.Value
+encodeV1 toast =
+    [ Maybe.map (\title -> ( "title", Encode.string title )) toast.title
+    , Just ( "message", Encode.string toast.message )
+    , Maybe.map (\custom -> ( "custom", custom )) toast.custom
+    ]
+        |> List.filterMap identity
+        |> Encode.object
+        |> withLabel "toastRequest"

--- a/tests/ToastMessage.elm
+++ b/tests/ToastMessage.elm
@@ -3,7 +3,7 @@ module ToastMessage exposing (suite)
 import Expect exposing (Expectation)
 import Fixture.ToastMessage as Fixture exposing (toastFuzzer, v1Fuzzer)
 import Json.Decode as Decode exposing (decodeValue)
-import Message.Toast as Toast
+import Message.Toast as Toast exposing (Toast)
 import Test exposing (..)
 
 
@@ -21,10 +21,11 @@ suite =
                     |> decodeValue Toast.decoder
                     |> Expect.equal
                         (Ok
-                            { title = v1Toast.title |> Maybe.withDefault "Notification!"
-                            , message = v1Toast.message
-                            , custom = v1Toast.custom
-                            , icon = "info"
-                            }
+                            (Toast
+                                (v1Toast.title |> Maybe.withDefault "Notification!")
+                                v1Toast.message
+                                v1Toast.custom
+                                "info"
+                            )
                         )
         ]

--- a/tests/ToastMessage.elm
+++ b/tests/ToastMessage.elm
@@ -1,7 +1,7 @@
 module ToastMessage exposing (suite)
 
 import Expect exposing (Expectation)
-import Fixture.ToastMessage exposing (toastFuzzer)
+import Fixture.ToastMessage as Fixture exposing (toastFuzzer, v1Fuzzer)
 import Json.Decode as Decode exposing (decodeValue)
 import Message.Toast as Toast
 import Test exposing (..)
@@ -15,4 +15,16 @@ suite =
                 Toast.encode toast
                     |> decodeValue Toast.decoder
                     |> Expect.equal (Ok toast)
+        , fuzz v1Fuzzer "Can decode old messages" <|
+            \v1Toast ->
+                Fixture.encodeV1 v1Toast
+                    |> decodeValue Toast.decoder
+                    |> Expect.equal
+                        (Ok
+                            { title = v1Toast.title |> Maybe.withDefault "Notification!"
+                            , message = v1Toast.message
+                            , custom = v1Toast.custom
+                            , icon = "info"
+                            }
+                        )
         ]


### PR DESCRIPTION
This is an example of how Elm enforces semver, and how decoders are good for maintaining backward compatibility with previous message formats. This PR is from another repo where I've previously published the package as in the `versioning-test` branch to the Elm ecosystem under a different name. Here's what happens if I just try to publish it again:

```
▶ elm publish
  Verifying MattCheely/tryframe-coordinator 2.0.0 ...

    ● Found README.md
    ● Found LICENSE
    ✗ Version 2.0.0 is not correct!

  -- ALREADY PUBLISHED -----------------------------------------------------------

  Version 2.0.0 has already been published. You cannot publish it again!
  Try using the `bump` command:

      elm bump

  It computes the version number based on API changes, ensuring that no breaking
  changes end up in PATCH releases!
```

It warns me I have to run a command to update the version. Before that, I can run `elm diff` to see the API changes:

```
▶ elm diff
This is a MAJOR change.

---- Message.Toast - MAJOR ----

    Changed:
      - type alias Toast =
            { title : Maybe String, message : String, custom : Maybe Value }
      + type alias Toast =
            { title : String.String
            , message : String.String
            , custom : Maybe.Maybe Json.Decode.Value
            , icon : String.String
            }
```

It shows the changes, which are clearly breaking. The `title` field is no longer optional, and there's a new `icon` field which is also required. Running `elm bump` yields: 

```
▶ elm bump
Based on your new API, this should be a MAJOR change (2.0.0 => 3.0.0)
Bail out of this command and run 'elm diff' for a full explanation.

Should I perform the update (2.0.0 => 3.0.0) in elm.json? [Y/n]
Version changed to 3.0.0!
```

From here, it's a matter of committing the changes, tagging the commit, and the package can be published. 

The big picture idea here is that we can base the npm package's version off of the Elm package's version, so that we always catch breaking changes. The downside is that I think it is possible that Elm may at times consider a change which _could_ be minor from the JS side as major within the context of Elm.

This doesn't solve every problem with compatibility. We can still break APIs in a way that will cause problems for out-of-sync deploys (like changing the label), but I don't know of a set of tools for TypeScript that provides as much automatically, with both compile-time and runtime-checks.