### PR TITLE
Ignore .d.ts file for tslint, since they are ignored lint script

### DIFF
--- a/js/iframe-coordinator/libs/Elm.d.ts
+++ b/js/iframe-coordinator/libs/Elm.d.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:variable-name no-empty-interface */
 interface LabeledMsg {
   msgType: string;
   msg: any;

--- a/js/iframe-coordinator/tslint.json
+++ b/js/iframe-coordinator/tslint.json
@@ -1,7 +1,7 @@
 {
     "extends": ["tslint:recommended", "tslint-config-prettier"],
     "linterOptions": {
-      "exclude": ["node_modules/**/*.ts"]
+      "exclude": ["node_modules/**/*.ts", "**/*.d.ts"]
     },
     "rules": {
       "interface-name": [true, "never-prefix"],


### PR DESCRIPTION
I noticed an issue while merging the tslint changes.  By default tslint doesn't look for .d.ts files (https://github.com/palantir/tslint/issues/3966).

However, if you include them in your pre-commit, it will check them.  Thus the lint script was ignoring issues that the pre-commit started to look for.

This change makes it so they are consistent.
