### PR TITLE
Move build scripts to npm ci instead of install

### DIFF
--- a/scripts/buildall.sh
+++ b/scripts/buildall.sh
@@ -6,5 +6,5 @@ ${PROJ_DIR}/scripts/buildlibs.sh
 
 echo "** Building & running demo-app **"
 cd ${PROJ_DIR}/demo-app
-npm install
+npm ci 
 npm start

--- a/scripts/buildlibs.sh
+++ b/scripts/buildlibs.sh
@@ -3,5 +3,5 @@
 PROJ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )/.."
 
 echo "** Building iframe-coordinator js bindings **"
-npm install
+npm ci 
 npm run build


### PR DESCRIPTION
This ensures the lockfile is used for standard runs and lets devs update the lockfile as needed through standard npm commands.