### PR TITLE
Pass assigned route to client via env data

### DIFF
--- a/src/HostRouter.ts
+++ b/src/HostRouter.ts
@@ -22,14 +22,16 @@ export class HostRouter {
   public getClientTarget(route: string): ClientTarget {
     let clientTarget: ClientTarget = {
       id: null,
-      url: null
+      url: null,
+      assignedRoute: null
     };
     this._clients.forEach(client => {
       const clientRoute = matchAndStripPrefix(route, client.assignedRoute);
       if (clientRoute !== null) {
         clientTarget = {
           id: client.id,
-          url: applyRoute(client.url, clientRoute)
+          url: applyRoute(client.url, clientRoute),
+          assignedRoute: client.assignedRoute
         };
       }
     });
@@ -49,6 +51,8 @@ export interface ClientTarget {
   id: string | null;
   /** The target URL to show */
   url: string | null;
+  /** The assigned route of the client */
+  assignedRoute: string | null;
 }
 
 /**

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -145,7 +145,6 @@ class FrameRouterElement extends HTMLElement {
       ...this._envData,
       assignedRoute
     };
-    window.console.log('envData', envData);
     this._frameManager.sendToClient({
       msgType: 'env_init',
       msg: envData

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -138,9 +138,17 @@ class FrameRouterElement extends HTMLElement {
   }
 
   private _handleLifecycleMessage(message: LabeledStarted) {
+    const currentRoutePath = this.getAttribute(ROUTE_ATTR) || '';
+    const clientInfo = this._router.getClientTarget(currentRoutePath);
+    const assignedRoute = (clientInfo && clientInfo.assignedRoute) || '';
+    const envData = {
+      ...this._envData,
+      assignedRoute
+    };
+    window.console.log('envData', envData);
     this._frameManager.sendToClient({
       msgType: 'env_init',
-      msg: this._envData
+      msg: envData
     });
   }
 

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -138,9 +138,7 @@ class FrameRouterElement extends HTMLElement {
   }
 
   private _handleLifecycleMessage(message: LabeledStarted) {
-    const currentRoutePath = this.getAttribute(ROUTE_ATTR) || '';
-    const clientInfo = this._router.getClientTarget(currentRoutePath);
-    const assignedRoute = (clientInfo && clientInfo.assignedRoute) || '';
+    const assignedRoute = this._getCurrentClientAssignedRoute();
     const envData = {
       ...this._envData,
       assignedRoute
@@ -158,6 +156,12 @@ class FrameRouterElement extends HTMLElement {
     this.dispatchEvent(
       new CustomEvent(message.msgType, { detail: messageDetail })
     );
+  }
+
+  private _getCurrentClientAssignedRoute() {
+    const currentRoutePath = this.getAttribute(ROUTE_ATTR) || '';
+    const clientInfo = this._router.getClientTarget(currentRoutePath);
+    return (clientInfo && clientInfo.assignedRoute) || '';
   }
 }
 

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -53,6 +53,7 @@ const envDataDecoder = guard(
   object({
     locale: string,
     hostRootUrl: string,
+    assignedRoute: string,
     custom: mixed
   })
 );

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -32,6 +32,8 @@ export interface EnvData {
   locale: string;
   /** Location of the host app */
   hostRootUrl: string;
+  /** assigned route of the client */
+  assignedRoute: string;
   /** Extra host-specific details */
   custom?: any;
 }

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -98,7 +98,8 @@ describe('HostToClient', () => {
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
-          hostRootUrl: 'http://example.com/'
+          hostRootUrl: 'http://example.com/',
+          assignedRoute: 'app1'
         }
       };
       let testResult: HostToClient | null;
@@ -116,6 +117,7 @@ describe('HostToClient', () => {
         msg: {
           locale: 'nl-NL',
           hostRootUrl: 'http://example.com/',
+          assignedRoute: 'app1',
           custom: {
             appContext: 'MyApp'
           }

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -50,6 +50,7 @@ describe('client', () => {
     const testEnvironmentData: EnvData = {
       locale: 'nl-NL',
       hostRootUrl: 'http://example.com/',
+      assignedRoute: 'app1',
       custom: undefined
     };
     beforeEach(() => {


### PR DESCRIPTION
This PR allows client to know its own assigned route in the host app. Then the client can know its real URL in user's browser with `hostRootUrl` and `assignedRoute`.

With this PR, in sample app, the client side can see the `assignedRoute `.

![image](https://user-images.githubusercontent.com/12524095/61270400-92589c80-a76f-11e9-8a53-1072b5415de0.png)


Do we need to pass the whole url instead of just assigned route? because the real URL in browser would contain # in the url.

If the host always uses the hash router, then only `assignedRoute` and `hostRootUrl` should be enough for client.

