### PR TITLE
Add route assenged as private

### DIFF
--- a/client-app-example/ifc-cli.config.js
+++ b/client-app-example/ifc-cli.config.js
@@ -14,10 +14,10 @@ module.exports = function(frameRouter) {
     },
     {
       locale: 'en-US',
-      hostRootUrl: window.location.origin,
+      hostRootUrl: window.location.origin + '/#/',
       registeredKeys: [
         { key: 'a', ctrlKey: true },
-        { key: 'b', altKey: true }, 
+        { key: 'b', altKey: true },
         { key: 'a', ctrlKey: true, shiftKey: true }
       ],
       custom: getCustomClientData()

--- a/client-app-example/public/client-app-1/index.html
+++ b/client-app-example/public/client-app-1/index.html
@@ -13,10 +13,12 @@
 
     <h3>Change Route</h3>
     <ul>
-      <li><a href="#/app1/route1">This client: /route1</a></li>
-      <li><a href="#/app1/route2">This client: /route2</a></li>
-      <li><a href="#/app2/route1">Other client: /route1</a></li>
-      <li><a href="#/app2/route2">Other client: /route2</a></li>
+      <!-- internal routes URLs get remapped in js by `transformLinks` -->
+      <li><a href="#/route1">This client: /route1</a></li>
+      <li><a href="#/route2">This client: /route2</a></li>
+      <!-- External URLs use full links so they open nicely in new tabs -->
+      <li><a href="localhost:3000/#/app2/route1">Other client: /route1</a></li>
+      <li><a href="localhost:3000/#/app2/route2">Other client: /route2</a></li>
     </ul>
 
     <h2>Toasts</h2>

--- a/client-app-example/public/client-app-1/index.html
+++ b/client-app-example/public/client-app-1/index.html
@@ -8,6 +8,8 @@
     <h2>Routing</h2>
     <h3>Current Local Route:</h3>
     <div id="path"></div>
+    <h3>Current Host Route:</h3>
+    <div id="hostPath"></div>
 
     <h3>Change Route</h3>
     <ul>

--- a/client-app-example/public/client-app-2/index.html
+++ b/client-app-example/public/client-app-2/index.html
@@ -8,6 +8,8 @@
     <h2>Routing</h2>
     <h3>Current Local Route:</h3>
     <div id="path"></div>
+    <h3>Current Host Route:</h3>
+    <div id="hostPath"></div>
 
     <h3>Change Route</h3>
     <ul>

--- a/client-app-example/public/client-app-2/index.html
+++ b/client-app-example/public/client-app-2/index.html
@@ -13,10 +13,16 @@
 
     <h3>Change Route</h3>
     <ul>
-      <li><a href="#/app1/route1">Other client: /route1</a></li>
-      <li><a href="#/app1/route2">Other client: /route2</a></li>
-      <li><a href="#/app2/route1">This client: /route1</a></li>
-      <li><a href="#/app2/route2">This client: /route2</a></li>
+      <!-- External URLs use full links so they open nicely in new tabs -->
+      <li>
+        <a href="https://localhost:3000/#/app1/route1">Other client: /route1</a>
+      </li>
+      <li>
+        <a href="https://localhost:3000/#/app1/route2">Other client: /route2</a>
+      </li>
+      <!-- internal routes URLs get remapped in js by `transformLinks` -->
+      <li><a href="#/route1">This client: /route1</a></li>
+      <li><a href="#/route2">This client: /route2</a></li>
     </ul>
 
     <h2>Toasts</h2>

--- a/client-app-example/src/client.js
+++ b/client-app-example/src/client.js
@@ -9,6 +9,7 @@ document.getElementById('path').innerHTML = window.location.hash;
 
 window.onhashchange = function() {
   document.getElementById('path').innerHTML = window.location.hash;
+  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(window.location.hash);
 };
 
 /****  SET UP THE IFRAME CLIENT LIBRARY ****/
@@ -30,7 +31,7 @@ iframeClient.addListener('environmentalData', envData => {
   console.log(
     `Got locale from host. Current date formatted for ${envData.locale} is: ${localizedDate}`
   );
-  console.log(`current host url is ${iframeClient.hostURL}`)
+  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(window.location.hash);
   displayEnvData(envData);
 });
 

--- a/client-app-example/src/client.js
+++ b/client-app-example/src/client.js
@@ -9,7 +9,9 @@ document.getElementById('path').innerHTML = window.location.hash;
 
 window.onhashchange = function() {
   document.getElementById('path').innerHTML = window.location.hash;
-  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(window.location.hash);
+  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(
+    window.location.hash
+  );
 };
 
 /****  SET UP THE IFRAME CLIENT LIBRARY ****/
@@ -24,14 +26,20 @@ let iframeClient = new Client({
 // Add a listener that will handled config data passed from the host to the
 // client at startup.
 iframeClient.addListener('environmentalData', envData => {
-  const appLocale = envData.locale;
+  // Transform link URLs to match top-level app.
+  transformLinks();
 
+  const appLocale = envData.locale;
   const now = new Date();
   const localizedDate = new Intl.DateTimeFormat(appLocale).format(now);
   console.log(
-    `Got locale from host. Current date formatted for ${envData.locale} is: ${localizedDate}`
+    `Got locale from host. Current date formatted for ${
+      envData.locale
+    } is: ${localizedDate}`
   );
-  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(window.location.hash);
+  document.getElementById('hostPath').innerHTML = iframeClient.asHostUrl(
+    window.location.hash
+  );
   displayEnvData(envData);
 });
 
@@ -81,6 +89,11 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // HELPER FUNCTIONS
+function transformLinks() {
+  document.querySelectorAll('a[href^="#"]').forEach(link => {
+    link.href = iframeClient.asHostUrl(link.getAttribute('href'));
+  });
+}
 
 function displayEnvData(envData) {
   document.getElementById('env-data').innerHTML = JSON.stringify(

--- a/client-app-example/src/client.js
+++ b/client-app-example/src/client.js
@@ -30,6 +30,7 @@ iframeClient.addListener('environmentalData', envData => {
   console.log(
     `Got locale from host. Current date formatted for ${envData.locale} is: ${localizedDate}`
   );
+  console.log(`current host url is ${iframeClient.hostURL}`)
   displayEnvData(envData);
 });
 

--- a/src/HostRouter.ts
+++ b/src/HostRouter.ts
@@ -1,4 +1,9 @@
 // Main Class
+import {
+  normalizeRoute,
+  stripLeadingSlash,
+  stripTrailingSlash
+} from './urlUtils';
 
 /**
  * HostRouter is responsible for mapping route paths to
@@ -155,32 +160,4 @@ function applyRoute(urlStr: string, route: string): string {
     newUrl.pathname = `${baseClientPath}/${route}`;
   }
   return newUrl.toString();
-}
-
-/**
- * Removes leading and trailing slashes from a route to simplify comparisons
- * against other paths.
- *
- * @external
- */
-function normalizeRoute(route: string): string {
-  return stripLeadingSlash(stripTrailingSlash(route));
-}
-
-/**
- * Removes any leading '/' characters from a string.
- *
- * @external
- */
-function stripLeadingSlash(str: string): string {
-  return str.replace(/^\/+/, '');
-}
-
-/**
- * Removes any trailing '/' characters from a string.
- *
- * @external
- */
-function stripTrailingSlash(str: string): string {
-  return str.replace(/\/+$/, '');
 }

--- a/src/HostRouter.ts
+++ b/src/HostRouter.ts
@@ -22,14 +22,16 @@ export class HostRouter {
   public getClientTarget(route: string): ClientTarget {
     let clientTarget: ClientTarget = {
       id: null,
-      url: null
+      url: null,
+      assignedRoute: null
     };
     this._clients.forEach(client => {
       const clientRoute = matchAndStripPrefix(route, client.assignedRoute);
       if (clientRoute !== null) {
         clientTarget = {
           id: client.id,
-          url: applyRoute(client.url, clientRoute)
+          url: applyRoute(client.url, clientRoute),
+          assignedRoute: client.assignedRoute
         };
       }
     });
@@ -49,6 +51,8 @@ export interface ClientTarget {
   id: string | null;
   /** The target URL to show */
   url: string | null;
+  /** The assigned route of the client */
+  assignedRoute: string | null;
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ export class Client {
   private _publishEmitter: InternalEventEmitter<Publication>;
   private _publishExposedEmitter: EventEmitter<Publication>;
   private _registeredKeys: KeyData[];
-  private _assignedRoute: string | undefined;
+  private _assignedRoute: string;
 
   /**
    * Creates a new client.

--- a/src/client.ts
+++ b/src/client.ts
@@ -193,7 +193,7 @@ export class Client {
   /**
    * Gets the host url prefix for current app
    */
-  public asHostUrl(clientRoute: string) {
+  public asHostUrl(clientRoute: string): string {
     const trimedClientRoute = stripLeadingSlashAndHashTag(clientRoute);
     return joinRoutes(
       this.environmentData.hostRootUrl,

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,7 @@ export class Client {
   private _publishEmitter: InternalEventEmitter<Publication>;
   private _publishExposedEmitter: EventEmitter<Publication>;
   private _registeredKeys: KeyData[];
+  private _assignedRoute: string | undefined;
 
   /**
    * Creates a new client.
@@ -56,6 +57,7 @@ export class Client {
     );
     this._envDataEmitter = new InternalEventEmitter<EnvData>();
     this._registeredKeys = [];
+    this._assignedRoute = '';
   }
 
   /**
@@ -144,7 +146,9 @@ export class Client {
 
   private _handleEnvironmentData(message: HostToClient): void {
     const envInitMsg: LabeledEnvInit = message as LabeledEnvInit;
-    this._environmentData = envInitMsg.msg;
+    const { assignedRoute, ...envData } = envInitMsg.msg;
+    this._assignedRoute = assignedRoute;
+    this._environmentData = envData;
 
     if (this._environmentData.registeredKeys) {
       this._environmentData.registeredKeys.forEach(keyData => {
@@ -183,6 +187,13 @@ export class Client {
    */
   public get environmentData() {
     return this._environmentData;
+  }
+
+  /**
+   * Gets the host url prefix for current app
+   */
+  public get hostURL() {
+    return `${this.environmentData.hostRootUrl}/#/${this._assignedRoute}`;
   }
 
   private _sendToHost(message: ClientToHost): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+import { joinRoutes, stripLeadingSlashAndHashTag } from '../src/urlUtils';
 import { EventEmitter, InternalEventEmitter } from './EventEmitter';
 import { keyEqual } from './Key';
 import {
@@ -192,8 +193,13 @@ export class Client {
   /**
    * Gets the host url prefix for current app
    */
-  public get hostURL() {
-    return `${this.environmentData.hostRootUrl}/#/${this._assignedRoute}`;
+  public asHostUrl(clientRoute: string) {
+    const trimedClientRoute = stripLeadingSlashAndHashTag(clientRoute);
+    return joinRoutes(
+      this.environmentData.hostRootUrl,
+      this._assignedRoute,
+      trimedClientRoute
+    );
   }
 
   private _sendToHost(message: ClientToHost): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,7 +40,7 @@ export class Client {
   private _publishEmitter: InternalEventEmitter<Publication>;
   private _publishExposedEmitter: EventEmitter<Publication>;
   private _registeredKeys: KeyData[];
-  private _assignedRoute: string;
+  private _assignedRoute: string | null;
 
   /**
    * Creates a new client.
@@ -58,7 +58,7 @@ export class Client {
     );
     this._envDataEmitter = new InternalEventEmitter<EnvData>();
     this._registeredKeys = [];
-    this._assignedRoute = '';
+    this._assignedRoute = null;
   }
 
   /**
@@ -197,7 +197,7 @@ export class Client {
     const trimedClientRoute = stripLeadingSlashAndHashTag(clientRoute);
     return joinRoutes(
       this.environmentData.hostRootUrl,
-      this._assignedRoute,
+      this._assignedRoute || '',
       trimedClientRoute
     );
   }

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -4,6 +4,7 @@ import { HostRouter, RoutingMap } from '../HostRouter';
 import { ClientToHost } from '../messages/ClientToHost';
 import { EnvData, EnvDataExt, LabeledStarted } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
+import { stripTrailingSlash } from '../urlUtils';
 
 /** @external */
 const ROUTE_ATTR = 'route';
@@ -66,7 +67,11 @@ class FrameRouterElement extends HTMLElement {
    */
   public setupFrames(clients: RoutingMap, envData: EnvData) {
     this._router = new HostRouter(clients);
-    this._envData = envData;
+    const processedHostUrl = this._processHostUrl(envData.hostRootUrl);
+    this._envData = {
+      ...envData,
+      hostRootUrl: processedHostUrl
+    };
 
     this.changeRoute(this.getAttribute(ROUTE_ATTR) || 'about:blank');
   }
@@ -163,6 +168,15 @@ class FrameRouterElement extends HTMLElement {
     const currentRoutePath = this.getAttribute(ROUTE_ATTR) || '';
     const clientInfo = this._router.getClientTarget(currentRoutePath);
     return (clientInfo && clientInfo.assignedRoute) || '';
+  }
+
+  private _processHostUrl(hostUrl: string) {
+    const hostUrlObject = new URL(hostUrl);
+    if (hostUrlObject.hash) {
+      return hostUrlObject.href;
+    }
+    const trimedUrl = stripTrailingSlash(hostUrl);
+    return window.location.hash ? `${trimedUrl}/#` : trimedUrl;
   }
 }
 

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -2,7 +2,7 @@ import { EventEmitter, InternalEventEmitter } from '../EventEmitter';
 import FrameManager from '../FrameManager';
 import { HostRouter, RoutingMap } from '../HostRouter';
 import { ClientToHost } from '../messages/ClientToHost';
-import { EnvData, LabeledStarted } from '../messages/Lifecycle';
+import { EnvData, EnvDataExt, LabeledStarted } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
 
 /** @external */
@@ -139,9 +139,14 @@ class FrameRouterElement extends HTMLElement {
   }
 
   private _handleLifecycleMessage(message: LabeledStarted) {
+    const assignedRoute = this._getCurrentClientAssignedRoute();
+    const envData: EnvDataExt = {
+      ...this._envData,
+      assignedRoute
+    };
     this._frameManager.sendToClient({
       msgType: 'env_init',
-      msg: this._envData
+      msg: envData
     });
   }
 
@@ -152,6 +157,12 @@ class FrameRouterElement extends HTMLElement {
     this.dispatchEvent(
       new CustomEvent(message.msgType, { detail: messageDetail })
     );
+  }
+
+  private _getCurrentClientAssignedRoute() {
+    const currentRoutePath = this.getAttribute(ROUTE_ATTR) || '';
+    const clientInfo = this._router.getClientTarget(currentRoutePath);
+    return (clientInfo && clientInfo.assignedRoute) || '';
   }
 }
 

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -2,7 +2,7 @@ import { EventEmitter, InternalEventEmitter } from '../EventEmitter';
 import FrameManager from '../FrameManager';
 import { HostRouter, RoutingMap } from '../HostRouter';
 import { ClientToHost } from '../messages/ClientToHost';
-import { EnvData, EnvDataExt, LabeledStarted } from '../messages/Lifecycle';
+import { EnvData, LabeledStarted, SetupData } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
 import { stripTrailingSlash } from '../urlUtils';
 
@@ -145,7 +145,7 @@ class FrameRouterElement extends HTMLElement {
 
   private _handleLifecycleMessage(message: LabeledStarted) {
     const assignedRoute = this._getCurrentClientAssignedRoute();
-    const envData: EnvDataExt = {
+    const envData: SetupData = {
       ...this._envData,
       assignedRoute
     };

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -49,7 +49,7 @@ export interface EnvData {
 /**
  * Extended Environmental data passed to client with some private data.
  */
-export interface EnvDataExt extends EnvData {
+export interface SetupData extends EnvData {
   /** assigned route of the client */
   assignedRoute: string;
 }
@@ -79,7 +79,7 @@ export interface LabeledEnvInit extends LabeledMsg {
   /** Message identifier */
   msgType: 'env_init';
   /** Environment data */
-  msg: EnvDataExt;
+  msg: SetupData;
 }
 
 /** @external */

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -47,6 +47,14 @@ export interface EnvData {
 }
 
 /**
+ * Extended Environmental data passed to client with some private data.
+ */
+export interface EnvDataExt extends EnvData {
+  /** assigned route of the client */
+  assignedRoute: string;
+}
+
+/**
  * A data structure representing a key.
  */
 export interface KeyData {
@@ -71,7 +79,7 @@ export interface LabeledEnvInit extends LabeledMsg {
   /** Message identifier */
   msgType: 'env_init';
   /** Environment data */
-  msg: EnvData;
+  msg: EnvDataExt;
 }
 
 /** @external */
@@ -79,6 +87,7 @@ const envDataDecoder = guard(
   object({
     locale: string,
     hostRootUrl: string,
+    assignedRoute: string,
     registeredKeys: array(
       object({
         key: string,

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -99,7 +99,8 @@ describe('HostToClient', () => {
         msg: {
           locale: 'nl-NL',
           hostRootUrl: 'http://example.com/',
-          registeredKeys: []
+          registeredKeys: [],
+          assignedRoute: 'app1'
         }
       };
       let testResult: HostToClient | null;
@@ -120,7 +121,8 @@ describe('HostToClient', () => {
           registeredKeys: [],
           custom: {
             appContext: 'MyApp'
-          }
+          },
+          assignedRoute: 'app1'
         }
       };
       let testResult: HostToClient | null;

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -1,5 +1,5 @@
 import { Client } from '../client';
-import { EnvData } from '../messages/Lifecycle';
+import { EnvData, EnvDataExt } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
 
 describe('client', () => {
@@ -48,11 +48,12 @@ describe('client', () => {
   describe('when an initial data environment is recieved', () => {
     let recievedEnvData: EnvData;
 
-    const testEnvironmentData: EnvData = {
+    const testEnvironmentData: EnvDataExt = {
       locale: 'nl-NL',
       hostRootUrl: 'http://example.com/',
       registeredKeys: [],
-      custom: undefined
+      custom: undefined,
+      assignedRoute: 'app1'
     };
     beforeEach(() => {
       client.addListener('environmentalData', (env: EnvData) => {
@@ -70,7 +71,8 @@ describe('client', () => {
     });
 
     it('should delegate', () => {
-      expect(recievedEnvData).toEqual(testEnvironmentData);
+      const { assignedRoute, ...restEnvData } = testEnvironmentData;
+      expect(recievedEnvData).toEqual(restEnvData);
     });
   });
 
@@ -190,11 +192,12 @@ describe('client', () => {
 
   describe('when window has a key event', () => {
     beforeEach(() => {
-      const testEnvironmentData: EnvData = {
+      const testEnvironmentData: EnvDataExt = {
         locale: 'nl-NL',
         hostRootUrl: 'http://example.com/',
         registeredKeys: [{ key: 'a', altKey: true }],
-        custom: undefined
+        custom: undefined,
+        assignedRoute: 'app1'
       };
 
       client.start();

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -1,5 +1,5 @@
 import { Client } from '../client';
-import { EnvData, EnvDataExt } from '../messages/Lifecycle';
+import { EnvData, SetupData } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
 
 describe('client', () => {
@@ -48,7 +48,7 @@ describe('client', () => {
   describe('when an initial data environment is recieved', () => {
     let recievedEnvData: EnvData;
 
-    const testEnvironmentData: EnvDataExt = {
+    const testEnvironmentData: SetupData = {
       locale: 'nl-NL',
       hostRootUrl: 'http://example.com/',
       registeredKeys: [],
@@ -73,6 +73,26 @@ describe('client', () => {
     it('should delegate', () => {
       const { assignedRoute, ...restEnvData } = testEnvironmentData;
       expect(recievedEnvData).toEqual(restEnvData);
+    });
+
+    describe('access host URL', () => {
+      it('should be able to access host url', () => {
+        const hostUrl = client.asHostUrl('client/route');
+        expect(hostUrl).toEqual('http://example.com/app1/client/route');
+      });
+
+      it('should ignore client route leading splash and hash tag', () => {
+        let hostUrl = client.asHostUrl('/client/route');
+        expect(hostUrl).toEqual('http://example.com/app1/client/route');
+        hostUrl = client.asHostUrl('#/client/route');
+        expect(hostUrl).toEqual('http://example.com/app1/client/route');
+        hostUrl = client.asHostUrl('/#/client/route');
+        expect(hostUrl).toEqual('http://example.com/app1/client/route');
+      });
+      it('should keep query strings', () => {
+        const hostUrl = client.asHostUrl('/#/client/route?foo=bar');
+        expect(hostUrl).toEqual('http://example.com/app1/client/route?foo=bar');
+      });
     });
   });
 
@@ -192,7 +212,7 @@ describe('client', () => {
 
   describe('when window has a key event', () => {
     beforeEach(() => {
-      const testEnvironmentData: EnvDataExt = {
+      const testEnvironmentData: SetupData = {
         locale: 'nl-NL',
         hostRootUrl: 'http://example.com/',
         registeredKeys: [{ key: 'a', altKey: true }],

--- a/src/urlUtils.ts
+++ b/src/urlUtils.ts
@@ -1,0 +1,45 @@
+/**
+ * Removes leading and trailing slashes from a route to simplify comparisons
+ * against other paths.
+ *
+ * @external
+ */
+export function normalizeRoute(route: string): string {
+  return stripLeadingSlash(stripTrailingSlash(route));
+}
+
+/**
+ * Removes any leading '/' characters from a string.
+ *
+ * @external
+ */
+export function stripLeadingSlash(str: string): string {
+  return str.replace(/^\/+/, '');
+}
+
+/**
+ * Removes any trailing '/' characters from a string.
+ *
+ * @external
+ */
+export function stripTrailingSlash(str: string): string {
+  return str.replace(/\/+$/, '');
+}
+
+/**
+ * Removes any leading '/' or '#' characters from a string.
+ *
+ * @external
+ */
+export function stripLeadingSlashAndHashTag(str: string): string {
+  return str.replace(/^(\/|#)+/, '');
+}
+
+/**
+ * Join multiple routes into one URL.
+ *
+ * @external
+ */
+export function joinRoutes(...routes: string[]): string {
+  return routes.map(route => normalizeRoute(route)).join('/');
+}


### PR DESCRIPTION
Created a new branch for the same purpose as https://github.com/purecloudlabs/iframe-coordinator/pull/66

This time the host will still pass the `assignedRoute` data in the `"env_init"` response.

And the client will extract the `assignedRoute` from the response and store it as a private variable.
Then expose the rest env data.

And client and use `client.hostURL` getter to get the whole current host url.

Is this `client.hostURL` a good getter name?