### PR TITLE
A humble request

### DIFF
--- a/cli/embedded-app/src/views/IframeEmbed.vue
+++ b/cli/embedded-app/src/views/IframeEmbed.vue
@@ -103,7 +103,6 @@ for more details.
   height: 100%;
 }
 #frameRouter {
-  position: relative;
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 100vh;

--- a/cli/embedded-app/src/views/IframeEmbed.vue
+++ b/cli/embedded-app/src/views/IframeEmbed.vue
@@ -103,6 +103,7 @@ for more details.
   height: 100%;
 }
 #frameRouter {
+  position: relative;
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 100vh;

--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -8,8 +8,21 @@ import {
 } from './messages/HostToClient';
 
 /** @external */
-const IFRAME_STYLE =
-  'position: absolute; top: 0; left: 0; width: 100%; height: 100%;';
+const IFRAME_STYLE = `
+frame-router {
+  position: relative;
+}
+
+frame-router iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+`;
+
+let style: HTMLElement;
 
 /**
  * A handler function for messages sent from a client app.
@@ -45,7 +58,13 @@ class FrameManager {
 
     this._iframe = this._window.document.createElement('iframe');
     this._iframe.setAttribute('frameborder', '0');
-    this._iframe.setAttribute('style', IFRAME_STYLE);
+
+    if (!style) {
+      style = this._window.document.createElement('style');
+      style.innerText = IFRAME_STYLE;
+      this._window.document.head.appendChild(style);
+    }
+
     this._iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
   }
 

--- a/src/elements/frame-router.ts
+++ b/src/elements/frame-router.ts
@@ -45,7 +45,6 @@ class FrameRouterElement extends HTMLElement {
    * @inheritdoc
    */
   public connectedCallback() {
-    this.setAttribute('style', 'position: relative;');
     this._frameManager.embed(this);
     this._frameManager.startMessageHandler();
   }


### PR DESCRIPTION
For our use case `position: relative` causes us issues and in order to override this styling in css we have to `!important` it. I would think that styling should be left completely up to the consumer of the frame-router.