### PR TITLE
Add nav request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Tools for coordinating embedded apps via iframes.",
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ import {
   LabeledEnvInit,
   Lifecycle
 } from './messages/Lifecycle';
+import { NavRequest } from './messages/NavRequest';
 import { Publication } from './messages/Publication';
 import { Toast } from './messages/Toast';
 
@@ -264,10 +265,28 @@ export class Client {
    * @example
    * `worker.requestToast({ title: 'Hello', message: 'World', custom: { ttl: 5, level: 'info' } });`
    */
-  public requestToast(toast: Toast) {
+  public requestToast(toast: Toast): void {
     this._sendToHost({
       msgType: 'toastRequest',
       msg: toast
+    });
+  }
+
+  /**
+   * Asks the host application to navigate to a new location.
+   *
+   * By requesting navigation from the host app instead of navigating directly in the client frame,
+   * a host-client pair can maintain a consistent browser history even if the client frame is removed
+   * from the page in some situations. It also helps avoid any corner-case differences in how older
+   * browsers handle iframe history
+   *
+   * @param destination a description of where the client wants to navigate the app to.
+   *
+   */
+  public requestNavigation(destination: NavRequest): void {
+    this._sendToHost({
+      msgType: 'navRequest',
+      msg: destination
     });
   }
 }

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -13,7 +13,10 @@ describe('FrameManager', () => {
         .createSpy('docCreateElement')
         .and.callFake((element: string) => {
           return mocks.frame;
-        })
+        }),
+      head: {
+        appendChild: jasmine.createSpy('headAppend')
+      }
     };
 
     mocks.window = {

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -261,6 +261,22 @@ describe('client', () => {
     });
   });
 
+  describe('when client requests to navigate to a new page', () => {
+    beforeEach(() => {
+      client.requestNavigation({ url: 'http://www.example.com/' });
+    });
+
+    it('should notify worker of navigation request', () => {
+      expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
+        {
+          msgType: 'navRequest',
+          msg: { url: 'http://www.example.com/' }
+        },
+        'https://example.com'
+      );
+    });
+  });
+
   describe('when window has a click event', () => {
     let mockElement;
     describe('when click event target is an anchor', () => {


### PR DESCRIPTION
This adds an API clients can use to request navigation programmatically. It's useful for redirect-like behaviors or cases where the basic link interception provided by the client doesn't work with the client framework.