### PR TITLE
[COMUI-54] Add protocol and version to cross-frame messages.

### DIFF
--- a/src/messages/KeyDown.ts
+++ b/src/messages/KeyDown.ts
@@ -8,14 +8,15 @@ import {
   string
 } from 'decoders';
 import { NativeKey } from '../Key';
-import { LabeledMsg } from './LabeledMsg';
+import { labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * A message used to send key information
  * to the host application.
  * @external
  */
-export interface LabeledKeyDown extends LabeledMsg {
+export interface LabeledKeyDown
+  extends LabeledMsg<'registeredKeyFired', NativeKey> {
   /** Message identifier */
   msgType: 'registeredKeyFired';
   /** Key details */
@@ -23,9 +24,9 @@ export interface LabeledKeyDown extends LabeledMsg {
 }
 
 /** @external */
-const decoder: Decoder<LabeledKeyDown> = object({
-  msgType: constant<'registeredKeyFired'>('registeredKeyFired'),
-  msg: object({
+const decoder: Decoder<LabeledKeyDown> = labeledDecoder(
+  constant<'registeredKeyFired'>('registeredKeyFired'),
+  object({
     altKey: optional(boolean),
     charCode: optional(number),
     code: optional(string),
@@ -35,6 +36,6 @@ const decoder: Decoder<LabeledKeyDown> = object({
     metaKey: optional(boolean),
     shiftKey: optional(boolean)
   })
-});
+);
 
 export { decoder };

--- a/src/messages/LabeledMsg.ts
+++ b/src/messages/LabeledMsg.ts
@@ -1,3 +1,16 @@
+import {
+  constant,
+  Decoder,
+  either,
+  hardcoded,
+  map,
+  object,
+  string
+} from 'decoders';
+import { version } from '../../package.json';
+
+export const API_PROTOCOL = 'iframe-coordinator';
+
 /**
  * Labeled message is a general structure
  * used by all coordinated messages between
@@ -8,9 +21,64 @@
  * information desired to be communicated.
  * @external
  */
-export interface LabeledMsg {
+export interface LabeledMsg<T, V> extends PartialMsg<T, V> {
+  /** Distinguisihes iframe-coordinator message from other postmessage events */
+  protocol: 'iframe-coordinator';
+  /** library version */
+  version: string;
+}
+
+/**
+ * Core data structure for most messages. These are the parts that vary by message type.
+ * @external
+ */
+export interface PartialMsg<T, V> {
   /** The type of message */
-  msgType: string;
+  msgType: T;
   /** The message payload */
-  msg: any;
+  msg: V;
+}
+
+/**
+ * Takes an object with a `msgType` and `msg` and applies the appropriate
+ * `protocol` and `version` fields for the current version of the library.
+ * @param partialMsg
+ * @external
+ */
+export function applyProtocol<T, V>(
+  partialMsg: PartialMsg<T, V>
+): LabeledMsg<T, V> {
+  return { ...partialMsg, protocol: API_PROTOCOL, version };
+}
+
+/**
+ * Converts a PartialMsg decoder into a LabeledMsg decoder
+ * @param msgDecoder
+ * @external
+ */
+export function labeledDecoder2<T, V>(
+  msgDecoder: Decoder<PartialMsg<T, V>>
+): Decoder<LabeledMsg<T, V>> {
+  return map(msgDecoder, applyProtocol);
+}
+
+/**
+ * Converts a PartialMsg decoder into a LabeledMsg decoder
+ * @param msgDecoder
+ * @external
+ */
+export function labeledDecoder<T, V>(
+  typeDecoder: Decoder<T>,
+  msgDecoder: Decoder<V>
+): Decoder<LabeledMsg<T, V>> {
+  return object({
+    // TODO: in 4.0.0 make protocol and verison fields mandatory
+    protocol: either(
+      constant<'iframe-coordinator'>(API_PROTOCOL),
+      hardcoded<'iframe-coordinator'>(API_PROTOCOL)
+    ),
+    version: either(string, hardcoded('unknown')),
+    msgType: typeDecoder,
+    msg: msgDecoder
+  });
 }

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -8,7 +8,7 @@ import {
   optional,
   string
 } from 'decoders';
-import { LabeledMsg } from './LabeledMsg';
+import { applyProtocol, labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * Client started indication.  The client will
@@ -16,17 +16,17 @@ import { LabeledMsg } from './LabeledMsg';
  * messages from the client application.
  * @external
  */
-export interface LabeledStarted extends LabeledMsg {
+export interface LabeledStarted extends LabeledMsg<'client_started', any> {
   /** Message identifier */
   msgType: 'client_started';
 }
 
 // We don't care what is in msg for Started messages.
 /** @external */
-const startedDecoder: Decoder<LabeledStarted> = object({
-  msgType: constant<'client_started'>('client_started'),
-  msg: mixed
-});
+const startedDecoder: Decoder<LabeledStarted> = labeledDecoder(
+  constant<'client_started'>('client_started'),
+  mixed
+);
 
 /**
  * Environmental data provided to all clients
@@ -72,7 +72,7 @@ export interface KeyData {
  * is sent to the client.
  * @external
  */
-export interface LabeledEnvInit extends LabeledMsg {
+export interface LabeledEnvInit extends LabeledMsg<'env_init', SetupData> {
   /** Message identifier */
   msgType: 'env_init';
   /** Environment data */
@@ -80,9 +80,9 @@ export interface LabeledEnvInit extends LabeledMsg {
 }
 
 /* @external */
-const envDecoder: Decoder<LabeledEnvInit> = object({
-  msgType: constant<'env_init'>('env_init'),
-  msg: object({
+const envDecoder: Decoder<LabeledEnvInit> = labeledDecoder(
+  constant<'env_init'>('env_init'),
+  object({
     locale: string,
     hostRootUrl: string,
     assignedRoute: string,
@@ -99,7 +99,7 @@ const envDecoder: Decoder<LabeledEnvInit> = object({
     ),
     custom: mixed
   })
-});
+);
 
 export { startedDecoder, envDecoder };
 
@@ -118,9 +118,9 @@ export class Lifecycle {
    * A {@link LabeledStarted} message to send to the host application.
    */
   public static get startedMessage(): LabeledStarted {
-    return {
+    return applyProtocol({
       msgType: 'client_started',
       msg: undefined
-    };
+    });
   }
 }

--- a/src/messages/NavRequest.ts
+++ b/src/messages/NavRequest.ts
@@ -1,5 +1,5 @@
 import { constant, Decoder, object, string } from 'decoders';
-import { LabeledMsg } from './LabeledMsg';
+import { labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * The navigation request data.
@@ -14,7 +14,8 @@ export interface NavRequest {
  * URI.
  * @external
  */
-export interface LabeledNavRequest extends LabeledMsg {
+export interface LabeledNavRequest
+  extends LabeledMsg<'navRequest', NavRequest> {
   /** Message identifier */
   msgType: 'navRequest';
   /** Navigation request details */
@@ -22,11 +23,11 @@ export interface LabeledNavRequest extends LabeledMsg {
 }
 
 /** @external */
-const decoder: Decoder<LabeledNavRequest> = object({
-  msgType: constant<'navRequest'>('navRequest'),
-  msg: object({
+const decoder: Decoder<LabeledNavRequest> = labeledDecoder(
+  constant<'navRequest'>('navRequest'),
+  object({
     url: string
   })
-});
+);
 
 export { decoder };

--- a/src/messages/Notification.ts
+++ b/src/messages/Notification.ts
@@ -8,7 +8,7 @@ import {
   optional,
   string
 } from 'decoders';
-import { LabeledMsg } from './LabeledMsg';
+import { labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * A toast configuration.
@@ -27,7 +27,8 @@ export interface Notification {
  * in the host application.
  * @external
  */
-export interface LabeledNotification extends LabeledMsg {
+export interface LabeledNotification
+  extends LabeledMsg<'notifyRequest', Notification> {
   /** Message identifier */
   msgType: 'notifyRequest';
   /** Toast details */
@@ -49,13 +50,13 @@ const toastTypeDecoder: Decoder<'notifyRequest'> = map(
 );
 
 /** @external */
-const decoder: Decoder<LabeledNotification> = object({
-  msgType: either(constant<'notifyRequest'>('notifyRequest'), toastTypeDecoder),
-  msg: object({
+const decoder: Decoder<LabeledNotification> = labeledDecoder(
+  either(constant<'notifyRequest'>('notifyRequest'), toastTypeDecoder),
+  object({
     title: optional(string),
     message: string,
     custom: mixed
   })
-});
+);
 
 export { decoder };

--- a/src/messages/Publication.ts
+++ b/src/messages/Publication.ts
@@ -1,5 +1,13 @@
-import { constant, Decoder, mixed, object, optional, string } from 'decoders';
-import { LabeledMsg } from './LabeledMsg';
+import {
+  constant,
+  Decoder,
+  map,
+  mixed,
+  object,
+  optional,
+  string
+} from 'decoders';
+import { labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * A publication configuration.
@@ -25,7 +33,7 @@ export interface Publication {
  * between the clients and the host application.
  * @external
  */
-export interface LabeledPublication extends LabeledMsg {
+export interface LabeledPublication extends LabeledMsg<'publish', Publication> {
   /** Message identifier */
   msgType: 'publish';
   /** Details of the data to publish */
@@ -33,13 +41,13 @@ export interface LabeledPublication extends LabeledMsg {
 }
 
 /** @external */
-const decoder: Decoder<LabeledPublication> = object({
-  msgType: constant<'publish'>('publish'),
-  msg: object({
+const decoder: Decoder<LabeledPublication> = labeledDecoder(
+  constant<'publish'>('publish'),
+  object({
     topic: string,
     payload: mixed,
     clientId: optional(string)
   })
-});
+);
 
 export { decoder };

--- a/src/messages/specs/ClientToHost.spec.ts
+++ b/src/messages/specs/ClientToHost.spec.ts
@@ -1,6 +1,7 @@
 import { ClientToHost, validate } from '../ClientToHost';
 import { LabeledNavRequest } from '../NavRequest';
 import { LabeledNotification } from '../Notification';
+import { LabeledPublication } from '../Publication';
 
 describe('ClientToHost', () => {
   describe('validating an invalid message type', () => {
@@ -17,45 +18,58 @@ describe('ClientToHost', () => {
   });
 
   describe('validating publish type', () => {
+    const withClientId = (message: any): any => {
+      message.msg.clientId = undefined;
+      return message;
+    };
+
     describe('when payload is a string', () => {
-      const testMessage: ClientToHost = {
+      const testMessage = {
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
           payload: 'test.payload'
         }
       };
-      let testResult: ClientToHost | null;
+
+      const expectedMessage = withClientId({
+        ...testMessage,
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      }) as LabeledPublication;
+
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
 
       it('should return the validated message', () => {
-        expect(testResult).toEqual({
-          msgType: testMessage.msgType,
-          msg: { ...testMessage.msg, clientId: undefined }
-        });
+        expect(testResult).toEqual(expectedMessage);
       });
     });
 
     describe('when payload is an object', () => {
-      const testMessage: ClientToHost = {
+      const testMessage = {
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
           payload: { testData: 'test.data' }
         }
       };
-      let testResult: ClientToHost | null;
+
+      const expectedMessage = withClientId({
+        ...testMessage,
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      });
+
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
 
       it('should return the validated message', () => {
-        expect(testResult).toEqual({
-          msgType: testMessage.msgType,
-          msg: { ...testMessage.msg, clientId: undefined }
-        });
+        expect(testResult).toEqual(expectedMessage);
       });
     });
 
@@ -81,25 +95,29 @@ describe('ClientToHost', () => {
           topic: 'test.topic'
         }
       };
-      const expectedMessage: ClientToHost = {
+      const expectedMessage = {
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
           payload: undefined,
           clientId: undefined
-        }
-      };
-      let testResult: ClientToHost | null;
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      } as ClientToHost;
+
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
+
       it('should return the validated message', () => {
         expect(testResult).toEqual(expectedMessage);
       });
     });
   });
 
-  describe('validating toast type', () => {
+  describe('validating notification type', () => {
     describe('when only a message is provided', () => {
       const testMessage = {
         msgType: 'notifyRequest',
@@ -114,10 +132,12 @@ describe('ClientToHost', () => {
           title: undefined,
           message: 'toast.message',
           custom: undefined
-        }
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
       };
 
-      let testResult: ClientToHost | null;
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
@@ -142,10 +162,12 @@ describe('ClientToHost', () => {
           title: 'toast.title',
           message: 'toast.message',
           custom: undefined
-        }
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
       };
 
-      let testResult: ClientToHost | null;
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
@@ -165,8 +187,13 @@ describe('ClientToHost', () => {
         }
       };
 
-      const expectedMessage: ClientToHost = testMessage as LabeledNotification;
-      let testResult: ClientToHost | null;
+      const expectedMessage: ClientToHost = {
+        ...testMessage,
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      } as LabeledNotification;
+
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
@@ -202,14 +229,14 @@ describe('ClientToHost', () => {
         }
       };
 
-      expect(validate(toastMessage)).toEqual({
+      const expectedMessage = {
+        ...toastMessage,
         msgType: 'notifyRequest',
-        msg: {
-          title: 'toast.title',
-          message: 'toast.message',
-          custom: undefined
-        }
-      });
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      } as LabeledNotification;
+
+      expect(validate(toastMessage)).toEqual(expectedMessage);
     });
   });
 
@@ -222,14 +249,13 @@ describe('ClientToHost', () => {
         }
       };
 
-      const expectedMessage: LabeledNavRequest = {
-        msgType: 'navRequest',
-        msg: {
-          url: 'navRequest.url'
-        }
-      };
+      const expectedMessage = {
+        ...testMessage,
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
+      } as LabeledNavRequest;
 
-      let testResult: ClientToHost | null;
+      let testResult: ClientToHost;
       beforeEach(() => {
         testResult = validate(testMessage);
       });

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -1,4 +1,5 @@
 import { HostToClient, validate } from '../HostToClient';
+import { applyProtocol } from '../LabeledMsg';
 
 describe('HostToClient', () => {
   describe('validating an invalid message type', () => {
@@ -16,42 +17,46 @@ describe('HostToClient', () => {
 
   describe('validating publish type', () => {
     describe('when payload is a string', () => {
-      const testMessage: HostToClient = {
+      const testMessage: HostToClient = applyProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
           payload: 'test.payload'
         }
-      };
+      });
       let testResult: HostToClient | null;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
       it('should return the validated message', () => {
-        expect(testResult).toEqual({
-          msgType: 'publish',
-          msg: { ...testMessage.msg, clientId: undefined }
-        });
+        expect(testResult).toEqual(
+          applyProtocol({
+            msgType: 'publish',
+            msg: { ...testMessage.msg, clientId: undefined }
+          })
+        );
       });
     });
 
     describe('when payload is an object', () => {
-      const testMessage: HostToClient = {
+      const testMessage: HostToClient = applyProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
           payload: { testData: 'test.data' }
         }
-      };
+      });
       let testResult: HostToClient | null;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
       it('should return the validated message', () => {
-        expect(testResult).toEqual({
-          msgType: 'publish',
-          msg: { ...testMessage.msg, clientId: undefined }
-        });
+        expect(testResult).toEqual(
+          applyProtocol({
+            msgType: 'publish',
+            msg: { ...testMessage.msg, clientId: undefined }
+          })
+        );
       });
     });
 
@@ -83,9 +88,12 @@ describe('HostToClient', () => {
           topic: 'test.topic',
           payload: undefined,
           clientId: undefined
-        }
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
       };
-      let testResult: HostToClient | null;
+
+      let testResult: HostToClient;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
@@ -97,7 +105,7 @@ describe('HostToClient', () => {
 
   describe('validating env_init type', () => {
     describe('when given a proper environmental data payload', () => {
-      const testMessage: HostToClient = {
+      const testMessage: HostToClient = applyProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -105,22 +113,24 @@ describe('HostToClient', () => {
           registeredKeys: [],
           assignedRoute: 'app1'
         }
-      };
+      });
 
       it('should return the validated message', () => {
         const testResult = validate(testMessage);
-        expect(testResult).toEqual({
-          msgType: 'env_init',
-          msg: {
-            ...testMessage.msg,
-            custom: undefined
-          }
-        });
+        expect(testResult).toEqual(
+          applyProtocol({
+            msgType: 'env_init',
+            msg: {
+              ...testMessage.msg,
+              custom: undefined
+            }
+          })
+        );
       });
     });
 
     describe('when given a proper environmental data payload including custom data', () => {
-      const testMessage: HostToClient = {
+      const testMessage: HostToClient = applyProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -131,13 +141,13 @@ describe('HostToClient', () => {
           },
           assignedRoute: 'app1'
         }
-      };
+      });
       let testResult: HostToClient;
       beforeEach(() => {
         testResult = validate(testMessage);
       });
       it('should return the validated message', () => {
-        expect(testResult).toEqual(testMessage);
+        expect(testResult).toEqual(applyProtocol(testMessage));
       });
     });
 

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -1,5 +1,5 @@
 import FrameManager from '../FrameManager';
-import { HostToClient } from '../messages/HostToClient';
+import { API_PROTOCOL } from '../messages/LabeledMsg';
 
 describe('FrameManager', () => {
   let mocks: any;
@@ -125,7 +125,7 @@ describe('FrameManager', () => {
           topic: 'test.topic',
           payload: {}
         }
-      } as HostToClient;
+      };
       frameManager.sendToClient(message);
 
       expect(mocks.frame.contentWindow.postMessage).not.toHaveBeenCalled();
@@ -138,7 +138,7 @@ describe('FrameManager', () => {
           topic: 'test.topic',
           payload: {}
         }
-      } as HostToClient;
+      };
       frameManager.setFrameLocation('http://example.com:4040/foo/bar/baz/');
       frameManager.sendToClient(message);
 
@@ -148,7 +148,9 @@ describe('FrameManager', () => {
           msg: {
             ...message.msg,
             clientId: undefined
-          }
+          },
+          protocol: 'iframe-coordinator',
+          version: 'unknown'
         },
         'http://example.com:4040'
       );
@@ -161,7 +163,7 @@ describe('FrameManager', () => {
           topic: 'test.topic',
           payload: {}
         }
-      } as HostToClient;
+      };
       frameManager.setFrameLocation('/foo/bar/');
       frameManager.sendToClient(message);
 
@@ -171,7 +173,9 @@ describe('FrameManager', () => {
           msg: {
             ...message.msg,
             clientId: undefined
-          }
+          },
+          protocol: 'iframe-coordinator',
+          version: 'unknown'
         },
         'http://test.example.com'
       );
@@ -203,7 +207,9 @@ describe('FrameManager', () => {
         msg: {
           ...mocks.messageEvent.data.msg,
           clientId: undefined
-        }
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown'
       });
     });
 
@@ -219,11 +225,26 @@ describe('FrameManager', () => {
       expect(mocks.handler).not.toHaveBeenCalled();
     });
 
-    it('which are blocked if sent with invalid data', () => {
-      mocks.messageEvent.data = { msgType: 'notValid', msg: {} };
+    it('which throw exceptions if sent with invalid data from iframe-coordinator', () => {
+      mocks.messageEvent.data = {
+        protocol: API_PROTOCOL,
+        msgType: 'notValid',
+        msg: {}
+      };
       expect(() => {
         mocks.window.raise('message', mocks.messageEvent);
       }).toThrow();
+    });
+
+    it('which do not throw exceptions if sent with invalid data from other sources', () => {
+      mocks.messageEvent.data = {
+        protocol: 'whatev',
+        msgType: 'notValid',
+        msg: {}
+      };
+      expect(() => {
+        mocks.window.raise('message', mocks.messageEvent);
+      }).not.toThrow();
     });
 
     it('and can unsubscribe as well.', () => {
@@ -246,7 +267,7 @@ describe('FrameManager', () => {
           topic: 'test.topic',
           payload: {}
         }
-      } as HostToClient;
+      };
 
       frameManager.sendToClient(message);
       expect(mocks.frame.contentWindow.postMessage).toHaveBeenCalledWith(
@@ -255,7 +276,9 @@ describe('FrameManager', () => {
           msg: {
             ...message.msg,
             clientId: undefined
-          }
+          },
+          protocol: 'iframe-coordinator',
+          version: 'unknown'
         },
         'http://example.com'
       );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "module": "commonjs",
     "declaration": true,
     "declarationDir": "./dist",
-    "target": "es2015"
+    "target": "es2015",
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": []


### PR DESCRIPTION
This helps us not throw errors when other systems use postMessage with
data iframe-coordinator can't parse, and will provide useful details
when debugging issues.

The overall strategy here is to start including flags to indicate messages are from iframe-coordinator, and what version they were sent from.  For backwards compatibility, we don't require those fields, but we also won't throw an exception on bad messages if they aren't present.  That way we aren't throwing errors on postmessage events from other systems. 

This change also includes some improvements to the types around our internal messages, to help build some better tooling and cut down on redundancy, so you'll see a lot of generics on message types.