### PR TITLE
Fix issue with build not generating .d.ts type declarations.

### DIFF
--- a/src/messages/LabeledMsg.ts
+++ b/src/messages/LabeledMsg.ts
@@ -7,7 +7,13 @@ import {
   object,
   string
 } from 'decoders';
-import { version } from '../../package.json';
+
+// using `import` here with TypeScripts' requireJsonModule
+// option breaks TS' ability to generate type files, so we
+// fall back to `require`.
+
+// tslint:disable-next-line:no-var-requires
+const version = require('../../package.json').version;
 
 export const API_PROTOCOL = 'iframe-coordinator';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "module": "commonjs",
     "declaration": true,
     "declarationDir": "./dist",
-    "target": "es2015",
-    "resolveJsonModule": true
+    "target": "es2015"
   },
   "include": ["src"],
   "exclude": []


### PR DESCRIPTION
This was apparently the result of using the requireJsonModule flag to
enable import of package.json to get the library version. It didn't get
caught locally because previous builds had already generated the type
files.