### PR TITLE
Improved error logging

### DIFF
--- a/cli/embedded-app/src/main.ts
+++ b/cli/embedded-app/src/main.ts
@@ -14,6 +14,10 @@ import store from './store';
 
 registerCustomElements();
 
+window.addEventListener('error', evt => {
+  console.error('Uncaught Error:', evt.error);
+});
+
 Vue.config.productionTip = false;
 
 Vue.use(Notifications);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Tools for coordinating embedded apps via iframes.",
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",


### PR DESCRIPTION
Just making sure when running the ifc-cli app if something fails, either due to a bug or bad data from a client app, something will be logged regardless of which browser is in use.