### PR TITLE
Ifc cli not found

### DIFF
--- a/cli/embedded-app/src/views/IframeEmbed.vue
+++ b/cli/embedded-app/src/views/IframeEmbed.vue
@@ -6,6 +6,23 @@
       as
       <span class="frame-url">{{ frameUrl }}</span>
     </div>
+    <div v-if="showMenu" id="appMenu">
+      <h2>No app is registered for {{ frameRoute }}</h2>
+
+      <div v-if="Object.keys(clientConfig).length > 0">
+        <p>To see your embedded apps, use one of the links below.</p>
+        <nav>
+          <ul>
+            <li v-for="(client, id) in clientConfig" v-bind:key="id">
+              <a v-bind:href="'#' + client.assignedRoute">{{id}} @ {{client.assignedRoute}}</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+      <div v-else>
+        <p>I couldn't find any registered client applications. Please check your ifc-cli configuration file.</p>
+      </div>
+    </div>
     <frame-router
       id="frameRouter"
       v-bind:route="frameRoute"
@@ -14,6 +31,7 @@
       v-on:navRequest="handleNav"
       v-on:frameTransition="updateFrameUrl"
     ></frame-router>
+    }}
   </div>
 </template>
 
@@ -23,7 +41,9 @@ export default {
   props: ['pathMatch'],
   data() {
     return {
-      frameUrl: ''
+      frameUrl: '',
+      showMenu: true,
+      clientConfig: {}
     };
   },
   computed: {
@@ -71,10 +91,17 @@ export default {
     },
     updateFrameUrl(event) {
       this.frameUrl = event.detail;
+      this.showMenu = this.frameUrl === 'about:blank';
     }
   },
   mounted() {
     // Call the custom config set up on the CLI.
+    const oldSetupFrames = frameRouter.setupFrames;
+    frameRouter.setupFrames = (...args) => {
+      this.clientConfig = args[0];
+      oldSetupFrames.apply(frameRouter, args);
+    };
+
     if (window.routerSetup && typeof window.routerSetup === 'function') {
       const clientConfig = window.routerSetup(frameRouter);
       if (clientConfig.publishTopics) {
@@ -118,5 +145,20 @@ for more details.
 #routerLayout .app-route,
 #routerLayout .frame-url {
   color: #ff4f1f;
+}
+
+#appMenu {
+  max-width: 80ch;
+  margin: auto;
+}
+#appMenu nav {
+  text-align: left;
+}
+#appMenu ul {
+  margin: 0;
+  padding: 0;
+}
+#appMenu li {
+  list-style: none;
 }
 </style>

--- a/cli/example-ifc.config.js
+++ b/cli/example-ifc.config.js
@@ -17,7 +17,7 @@ module.exports = function(frameRouter) {
       hostRootUrl: window.location.origin,
       registeredKeys: [
         { key: 'a', ctrlKey: true },
-        { key: 'b', altKey: true }, 
+        { key: 'b', altKey: true },
         { key: 'a', ctrlKey: true, shiftKey: true }
       ],
       custom: getCustomClientData()

--- a/client-app-example/ifc-cli.config.js
+++ b/client-app-example/ifc-cli.config.js
@@ -3,11 +3,11 @@ module.exports = function(frameRouter) {
 
   frameRouter.setupFrames(
     {
-      app1: {
+      application1: {
         url: 'http://' + hostname + ':8080/client-app-1/#/',
         assignedRoute: '/app1'
       },
-      app2: {
+      application2: {
         url: 'http://' + hostname + ':8080/client-app-2/#/',
         assignedRoute: '/app2',
         allow: 'camera http://localhost:8080;', // optional

--- a/client-app-example/public/client-app-1/index.html
+++ b/client-app-example/public/client-app-1/index.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../../client.css" />
   </head>
   <body>
-    <h1>Component #1</h1>
+    <h1>Application #1</h1>
 
     <h2>Routing</h2>
     <h3>Current Local Route:</h3>

--- a/client-app-example/public/client-app-2/index.html
+++ b/client-app-example/public/client-app-2/index.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../../client.css" />
   </head>
   <body>
-    <h1>Component #2</h1>
+    <h1>Application #2</h1>
 
     <div>
       <h3>Local Media</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "4.0.3",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-coordinator",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Tools for coordinating embedded apps via iframes.",
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",


### PR DESCRIPTION
I'm working on some quality-of-life improvements for ifc-cli and this is the first one. It updates the host app to show some useful details when you navigate to a route with no assigned clients. Users will either see a list of registered client apps (with links) or a message saying no clients have been registered.