### PR TITLE
Add proxy route for same-domain host and client hosting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Embedding applications via iframe also means that code from separate teams can b
  * We require a few polyfills in order to support IE11.  These
  * will be needed to be loaded by both the host and the client.
  */
-import "@babel/polyfill";
-import "custom-event-polyfill/polyfill.js";
-import "url-polyfill";
+import '@babel/polyfill';
+import 'custom-event-polyfill/polyfill.js';
+import 'url-polyfill';
 
 /* The iframe coordinator library uses custom elements to
  * embed itself in the host app. If you are targeting browsers
@@ -29,11 +29,11 @@ import "url-polyfill";
  * see: https://github.com/webcomponents/custom-elements for
  * more details on configuring the polyfill
  */
-import "@webcomponents/custom-elements/src/native-shim.js";
-import "@webcomponents/custom-elements/src/custom-elements.js";
+import '@webcomponents/custom-elements/src/native-shim.js';
+import '@webcomponents/custom-elements/src/custom-elements.js';
 
 /* Import the host library */
-import { registerCustomElements } from "iframe-coordinator/host.js";
+import { registerCustomElements } from 'iframe-coordinator/host.js';
 
 /* This will make the custom element `frame-router` available
  * for use in your browser. This element is the primary
@@ -56,21 +56,24 @@ registerCustomElements();
  * if the client uses pushstate path-based routing, leave the fragment out:
  * e.g. http://example.com/client/
  */
-document.getElementById("frame-element").setupFrames({
-  client1: {
-    url: "https://example.com/components/example1/#/",
-    assignedRoute: "/one"
+document.getElementById('frame-element').setupFrames(
+  {
+    client1: {
+      url: 'https://example.com/components/example1/#/',
+      assignedRoute: '/one'
+    },
+    client2: {
+      url: 'https://example.com/components/example2/#/',
+      assignedRoute: '/two',
+      sandbox: 'allow-presentation', // optional
+      allow: 'microphone https://example.com;' // optional
+    }
   },
-  client2: {
-    url: "https://example.com/components/example2/#/",
-    assignedRoute: "/two",
-    sandbox: 'allow-presentation', // optional
-    allow: 'microphone https://example.com;' // optional 
+  {
+    locale: 'en-US',
+    hostRootUrl: window.location.origin
   }
-}, {
-  locale: 'en-US',
-  hostRootUrl: window.location.origin
-});
+);
 ```
 
 **HTML/DOM**
@@ -183,6 +186,12 @@ Options:
   will be evaluated directly inside the browser in an immediately invoked
   function expression.
 
+  The CLI host app also provides a proxy route under `/proxy/` that can be used
+  if you need the client and host applicaitons on the same domain. To use the proxy,
+  simply make the url registered for the client that of the host app, followed by
+  `/proxy/` and then the url of the client app. (See `app2` in the config below
+  for an example)
+
   Here is an example config file:
 
 module.exports = function(frameRouter) {
@@ -193,10 +202,14 @@ module.exports = function(frameRouter) {
         assignedRoute: '/app1'
       },
       app2: {
-        url: 'http://localhost:8080/client-app-2/#/',
+        // Instead of directly referencing client 2 via "url: `http://${hostname}:8080/client-app-2/#/`"
+        // we use the built-in proxy route so it can share the same domain as the host app.
+        url: `${window.location.origin}/proxy/${encodeURI(
+          `http://${hostname}:8080/client-app-2/#/`
+        )}`,
         assignedRoute: '/app2',
         sandbox: 'allow-presentation', // optional
-        allow: 'microphone http://localhost:8080;' // optional 
+        allow: 'microphone http://localhost:8080;' // optional
       }
     },
     {
@@ -221,13 +234,17 @@ function getCustomClientData() {
 ### Building
 
 #### Installation
+
 Before you can build this you will need to make sure that you are using the LTS version of nodejs. Then you can run the following command `npm ci`
 
 #### Running the build
+
 To run the build you can use the following command `npm run build`
 
 #### Testing
+
 Testing can be done in a couple different ways
+
 ```
 npm run test # single run of tests
 npm run test.watch # continuous run of tests
@@ -235,6 +252,7 @@ npm run test.watch.chrome # continuous run of tests in a chromium browser.
 ```
 
 #### Running the example
+
 To see an example of this in action you can run the following command `npm run start-client-example` and navigate to http://localhost:3000 on your machine.
 
 ### IE11 support

--- a/client-app-example/ifc-cli.config.js
+++ b/client-app-example/ifc-cli.config.js
@@ -4,11 +4,17 @@ module.exports = function(frameRouter) {
   frameRouter.setupFrames(
     {
       application1: {
-        url: 'http://' + hostname + ':8080/client-app-1/#/',
+        url: `http://${hostname}:8080/client-app-1/#/`,
         assignedRoute: '/app1'
       },
       application2: {
-        url: 'http://' + hostname + ':8080/client-app-2/#/',
+        // Instead of directly referencing client 2 via "url: `http://${hostname}:8080/client-app-2/#/`"
+        // we use the built-in proxy route so it can share the same domain as the host app.
+        // This is useful if you want to test host and client sharing data through localstorage or other
+        // domain-restriceted APIs
+        url: `${window.location.origin}/proxy/${encodeURI(
+          `http://${hostname}:8080/client-app-2/#/`
+        )}`,
         assignedRoute: '/app2',
         allow: 'camera http://localhost:8080;', // optional
         sandbox: 'allow-presentation allow-modals' // optional

--- a/client-app-example/public/client-app-1/index.html
+++ b/client-app-example/public/client-app-1/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <link rel="stylesheet" href="../../client.css" />
+    <link rel="stylesheet" href="../client.css" />
   </head>
   <body>
     <h1>Application #1</h1>
@@ -17,8 +17,12 @@
       <li><a href="#/route1">This client: /route1</a></li>
       <li><a href="#/route2">This client: /route2</a></li>
       <!-- External URLs use full links so they open nicely in new tabs -->
-      <li><a href="localhost:3000/#/app2/route1">Other client: /route1</a></li>
-      <li><a href="localhost:3000/#/app2/route2">Other client: /route2</a></li>
+      <li>
+        <a href="//localhost:3000/#/app2/route1">Other client: /route1</a>
+      </li>
+      <li>
+        <a href="//localhost:3000/#/app2/route2">Other client: /route2</a>
+      </li>
     </ul>
 
     <h2>Toasts</h2>
@@ -41,6 +45,6 @@
     <h2>Environment Data from Host</h2>
     <pre id="env-data"></pre>
 
-    <script type="text/javascript" src="/client-app.js"></script>
+    <script type="text/javascript" src="../client-app.js"></script>
   </body>
 </html>

--- a/client-app-example/public/client-app-2/index.html
+++ b/client-app-example/public/client-app-2/index.html
@@ -1,21 +1,28 @@
 <html>
   <head>
-    <link rel="stylesheet" href="../../client.css" />
+    <link rel="stylesheet" href="../client.css" />
   </head>
   <body>
     <h1>Application #2</h1>
 
     <div>
       <h3>Local Media</h3>
-      <p>We are requesting the user's local video stream from within the iframe app.</p>
-      <p>We are able to request user media because we have allow="camera *;" set on the iframe</p>
+      <p>
+        We are requesting the user's local video stream from within the iframe
+        app.
+      </p>
+      <p>
+        We are able to request user media because we have allow="camera *;" set
+        on the iframe
+      </p>
 
       <video id="webrtc" autoplay style="height: auto; width: 150px;"></video>
 
       <script type="text/javascript">
         function requestPermissions() {
-          window.navigator.mediaDevices.getUserMedia({ video: true })
-            .then((stream) => {
+          window.navigator.mediaDevices
+            .getUserMedia({ video: true })
+            .then(stream => {
               document.querySelector('video#webrtc').srcObject = stream;
             });
         }
@@ -34,10 +41,10 @@
     <ul>
       <!-- External URLs use full links so they open nicely in new tabs -->
       <li>
-        <a href="https://localhost:3000/#/app1/route1">Other client: /route1</a>
+        <a href="//localhost:3000/#/app1/route1">Other client: /route1</a>
       </li>
       <li>
-        <a href="https://localhost:3000/#/app1/route2">Other client: /route2</a>
+        <a href="//localhost:3000/#/app1/route1">Other client: /route2</a>
       </li>
       <!-- internal routes URLs get remapped in js by `transformLinks` -->
       <li><a href="#/route1">This client: /route1</a></li>
@@ -64,6 +71,6 @@
     <h2>Environment Data from Host</h2>
     <pre id="env-data"></pre>
 
-    <script type="text/javascript" src="/client-app.js"></script>
+    <script type="text/javascript" src="../client-app.js"></script>
   </body>
 </html>

--- a/client-app-example/src/client.js
+++ b/client-app-example/src/client.js
@@ -47,8 +47,10 @@ iframeClient.messaging.addListener('host.topic', publication => {
   console.log('Got Publish event:', publication);
 });
 
-// Start intercepting link click events for cross-frame routing
+// Initialized the client
 iframeClient.start();
+// Intercept links for messaging
+iframeClient.startInterceptingLinks();
 
 /**** SET UP THE CLIENT UI ****/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,14 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/http-proxy": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.3.tgz",
+      "integrity": "sha512-wIPqXANye5BbORbuh74exbwNzj+UWCwWyeEFJzUQ7Fq3W2NSAy+7x7nX1fgbEypr2/TdKqpeuxLnXWgzN533/Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/jasmine": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.4.4.tgz",
@@ -2612,7 +2620,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
-      "dev": true,
       "requires": {
         "debug": "^3.2.6"
       },
@@ -2621,7 +2628,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2629,8 +2635,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3649,6 +3654,78 @@
         "requires-port": "^1.0.0"
       }
     },
+    "http-proxy-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.1.tgz",
+      "integrity": "sha512-tVLWnJMEUANithPrWeYgReU+mi6/BJOlyvWKQGS4k8L+j2ZjituJdXhejd31X5J8Ux0SSIH7Iw+RItH9bwkGcw==",
+      "requires": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "http-proxy": {
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+          "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "follow-redirects": "^1.0.0",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -3935,8 +4012,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-finite": {
       "version": "1.0.2",
@@ -3960,7 +4036,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -5432,6 +5507,11 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -5828,8 +5908,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "decoders": "^1.10.6",
     "dev-cert-authority": "^1.1.1",
     "express": "^4.17.1",
-    "find-root": "^1.1.0"
+    "find-root": "^1.1.0",
+    "http-proxy-middleware": "^1.0.1"
   },
   "files": [
     "dist/client.js",


### PR DESCRIPTION
This adds a built-in proxy route to `ifc-cli` so that the built in host app and local clients can live on the same domain from the browser's perspective, allowing shared localstorage and other domain-specific APIs. 