### PR TITLE
Remove dangling }} from the IframeEmbed view

### DIFF
--- a/cli/embedded-app/src/views/IframeEmbed.vue
+++ b/cli/embedded-app/src/views/IframeEmbed.vue
@@ -31,7 +31,6 @@
       v-on:navRequest="handleNav"
       v-on:frameTransition="updateFrameUrl"
     ></frame-router>
-    }}
   </div>
 </template>
 


### PR DESCRIPTION
An extra pair of closing braces in the IframeEmbed view is rendering as literal text when the cli wrapper app is used.