### PR TITLE
[QM-8327] Add allow-downloads flag to default sandbox

### DIFF
--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -26,7 +26,8 @@ const DEFAULT_SANDBOX = [
   'allow-same-origin',
   'allow-modals',
   'allow-forms',
-  'allow-popups'
+  'allow-popups',
+  'allow-downloads'
 ] as const;
 
 let style: HTMLElement;

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -75,7 +75,7 @@ describe('FrameManager', () => {
     expect(mocks.document.createElement).toHaveBeenCalledWith('iframe');
     expect(mocks.frame.setAttribute).toHaveBeenCalledWith(
       'sandbox',
-      'allow-scripts allow-same-origin allow-modals allow-forms allow-popups'
+      'allow-scripts allow-same-origin allow-modals allow-forms allow-popups allow-downloads'
     );
   });
 
@@ -315,7 +315,8 @@ describe('FrameManager', () => {
       'allow-same-origin',
       'allow-modals',
       'allow-forms',
-      'allow-popups'
+      'allow-popups',
+      'allow-downloads'
     ];
 
     it('add to the sandbox', () => {


### PR DESCRIPTION
As of Chrome 83, Chrome no longer allows sandboxed iframes to initiate downloads without the 'allow-downloads' flag set: https://www.chromestatus.com/feature/5706745674465280
Adding this flag to the FrameManager's default sandbox values preserves its previous behavior.