### PR TITLE
add support for nested iframe-coordinators

### DIFF
--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -6,7 +6,11 @@ import {
   HostToClient,
   validate as validateOutgoing
 } from './messages/HostToClient';
-import { API_PROTOCOL, PartialMsg } from './messages/LabeledMsg';
+import {
+  API_PROTOCOL,
+  applyHostProtocol,
+  PartialMsg
+} from './messages/LabeledMsg';
 
 /** @external */
 const IFRAME_STYLE = `
@@ -143,16 +147,14 @@ class FrameManager {
    *
    * @param message The message to send.
    */
-  public sendToClient<T, V>(message: PartialMsg<T, V>) {
+  public sendToClient<T, V>(partialMsg: PartialMsg<T, V>) {
     const clientOrigin = this._expectedClientOrigin();
     if (this._iframe.contentWindow && clientOrigin) {
+      const message = applyHostProtocol(partialMsg);
       let validated: HostToClient;
 
       try {
         validated = validateOutgoing(message);
-        if (validated.direction === undefined) {
-          validated.direction = 'HostToClient';
-        }
       } catch (e) {
         throw new Error(
           `

--- a/src/client.ts
+++ b/src/client.ts
@@ -102,6 +102,10 @@ export class Client {
   private _onWindowMessage = (event: MessageEvent) => {
     let validated = null;
 
+    if (event.data && event.data.direction === 'ClientToHost') {
+      return;
+    }
+
     try {
       validated = validateIncoming(event.data);
     } catch (e) {
@@ -231,10 +235,14 @@ export class Client {
 
   private _sendToHost<T, V>(partialMsg: PartialMsg<T, V>): void {
     const message = applyProtocol(partialMsg);
-    let validated = null;
+
+    let validated: ClientToHost;
 
     try {
       validated = validateOutgoing(message);
+      if (validated.direction === undefined) {
+        validated.direction = 'ClientToHost';
+      }
     } catch (e) {
       throw new Error(
         `

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,11 @@ import {
   HostToClient,
   validate as validateIncoming
 } from './messages/HostToClient';
-import { API_PROTOCOL, applyProtocol, PartialMsg } from './messages/LabeledMsg';
+import {
+  API_PROTOCOL,
+  applyClientProtocol,
+  PartialMsg
+} from './messages/LabeledMsg';
 import {
   EnvData,
   EnvDataHandler,
@@ -234,15 +238,12 @@ export class Client {
   }
 
   private _sendToHost<T, V>(partialMsg: PartialMsg<T, V>): void {
-    const message = applyProtocol(partialMsg);
+    const message = applyClientProtocol(partialMsg);
 
     let validated: ClientToHost;
 
     try {
       validated = validateOutgoing(message);
-      if (validated.direction === undefined) {
-        validated.direction = 'ClientToHost';
-      }
     } catch (e) {
       throw new Error(
         `

--- a/src/messages/LabeledMsg.ts
+++ b/src/messages/LabeledMsg.ts
@@ -59,15 +59,15 @@ export interface PartialMsg<T, V> {
 
 /**
  * Takes an object with a `msgType` and `msg` and applies the appropriate
- * `protocol` and `version` fields for the current version of the library.
+ * `direction`, `protocol` and `version` fields for the current version of the library.
  * @param partialMsg
  * @external
  */
-export function applyProtocol<T, V>(
+export function applyClientProtocol<T, V>(
   partialMsg: PartialMsg<T, V>
 ): LabeledMsg<T, V> {
   return {
-    direction: undefined,
+    direction: 'ClientToHost',
     ...partialMsg,
     protocol: API_PROTOCOL,
     version
@@ -75,14 +75,20 @@ export function applyProtocol<T, V>(
 }
 
 /**
- * Converts a PartialMsg decoder into a LabeledMsg decoder
- * @param msgDecoder
+ * Takes an object with a `msgType` and `msg` and applies the appropriate
+ * `direction`, `protocol` and `version` fields for the current version of the library.
+ * @param partialMsg
  * @external
  */
-export function labeledDecoder2<T, V>(
-  msgDecoder: Decoder<PartialMsg<T, V>>
-): Decoder<LabeledMsg<T, V>> {
-  return map(msgDecoder, applyProtocol);
+export function applyHostProtocol<T, V>(
+  partialMsg: PartialMsg<T, V>
+): LabeledMsg<T, V> {
+  return {
+    direction: 'HostToClient',
+    ...partialMsg,
+    protocol: API_PROTOCOL,
+    version
+  };
 }
 
 /**

--- a/src/messages/LabeledMsg.ts
+++ b/src/messages/LabeledMsg.ts
@@ -5,6 +5,7 @@ import {
   hardcoded,
   map,
   object,
+  optional,
   string
 } from 'decoders';
 
@@ -21,6 +22,12 @@ const version = require('../../package.json').version;
 export const API_PROTOCOL = 'iframe-coordinator';
 
 /**
+ * Based on MessageDirection, hosts and clients can ignore messages that are not targeted at them.
+ * @external
+ */
+export type MessageDirection = 'ClientToHost' | 'HostToClient';
+
+/**
  * Labeled message is a general structure
  * used by all coordinated messages between
  * host and client.
@@ -35,6 +42,8 @@ export interface LabeledMsg<T, V> extends PartialMsg<T, V> {
   protocol: 'iframe-coordinator';
   /** library version */
   version: string;
+  /** So that nested iframe-coordinators can ignore messages that don't apply */
+  direction?: MessageDirection;
 }
 
 /**
@@ -57,7 +66,12 @@ export interface PartialMsg<T, V> {
 export function applyProtocol<T, V>(
   partialMsg: PartialMsg<T, V>
 ): LabeledMsg<T, V> {
-  return { ...partialMsg, protocol: API_PROTOCOL, version };
+  return {
+    direction: undefined,
+    ...partialMsg,
+    protocol: API_PROTOCOL,
+    version
+  };
 }
 
 /**
@@ -81,13 +95,19 @@ export function labeledDecoder<T, V>(
   msgDecoder: Decoder<V>
 ): Decoder<LabeledMsg<T, V>> {
   return object({
-    // TODO: in 4.0.0 make protocol and verison fields mandatory
+    // TODO: in 4.0.0 make protocol and version fields mandatory
     protocol: either(
       constant<'iframe-coordinator'>(API_PROTOCOL),
       hardcoded<'iframe-coordinator'>(API_PROTOCOL)
     ),
     version: either(string, hardcoded('unknown')),
     msgType: typeDecoder,
-    msg: msgDecoder
+    msg: msgDecoder,
+    direction: optional(directionDecoder)
   });
 }
+
+const directionDecoder: Decoder<MessageDirection, unknown> = either(
+  constant('ClientToHost'),
+  constant('HostToClient')
+);

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -8,7 +8,7 @@ import {
   optional,
   string
 } from 'decoders';
-import { applyProtocol, labeledDecoder, LabeledMsg } from './LabeledMsg';
+import { applyClientProtocol, labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * Client started indication.  The client will
@@ -118,7 +118,7 @@ export class Lifecycle {
    * A {@link LabeledStarted} message to send to the host application.
    */
   public static get startedMessage(): LabeledStarted {
-    return applyProtocol({
+    return applyClientProtocol({
       msgType: 'client_started',
       msg: undefined
     });

--- a/src/messages/specs/ClientToHost.spec.ts
+++ b/src/messages/specs/ClientToHost.spec.ts
@@ -35,7 +35,8 @@ describe('ClientToHost', () => {
       const expectedMessage = withClientId({
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       }) as LabeledPublication;
 
       let testResult: ClientToHost;
@@ -60,7 +61,8 @@ describe('ClientToHost', () => {
       const expectedMessage = withClientId({
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       });
 
       let testResult: ClientToHost;
@@ -103,7 +105,8 @@ describe('ClientToHost', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as ClientToHost;
 
       let testResult: ClientToHost;
@@ -134,7 +137,8 @@ describe('ClientToHost', () => {
           custom: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: ClientToHost;
@@ -164,7 +168,8 @@ describe('ClientToHost', () => {
           custom: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: ClientToHost;
@@ -190,7 +195,8 @@ describe('ClientToHost', () => {
       const expectedMessage: ClientToHost = {
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNotification;
 
       let testResult: ClientToHost;
@@ -233,7 +239,8 @@ describe('ClientToHost', () => {
         ...toastMessage,
         msgType: 'notifyRequest',
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNotification;
 
       expect(validate(toastMessage)).toEqual(expectedMessage);
@@ -252,7 +259,8 @@ describe('ClientToHost', () => {
       const expectedMessage = {
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNavRequest;
 
       let testResult: ClientToHost;

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -1,5 +1,5 @@
 import { HostToClient, validate } from '../HostToClient';
-import { applyProtocol } from '../LabeledMsg';
+import { applyClientProtocol } from '../LabeledMsg';
 
 describe('HostToClient', () => {
   describe('validating an invalid message type', () => {
@@ -17,7 +17,7 @@ describe('HostToClient', () => {
 
   describe('validating publish type', () => {
     describe('when payload is a string', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
@@ -30,7 +30,7 @@ describe('HostToClient', () => {
       });
       it('should return the validated message', () => {
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'publish',
             msg: { ...testMessage.msg, clientId: undefined }
           })
@@ -39,7 +39,7 @@ describe('HostToClient', () => {
     });
 
     describe('when payload is an object', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
@@ -52,7 +52,7 @@ describe('HostToClient', () => {
       });
       it('should return the validated message', () => {
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'publish',
             msg: { ...testMessage.msg, clientId: undefined }
           })
@@ -106,7 +106,7 @@ describe('HostToClient', () => {
 
   describe('validating env_init type', () => {
     describe('when given a proper environmental data payload', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -119,7 +119,7 @@ describe('HostToClient', () => {
       it('should return the validated message', () => {
         const testResult = validate(testMessage);
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'env_init',
             msg: {
               ...testMessage.msg,
@@ -131,7 +131,7 @@ describe('HostToClient', () => {
     });
 
     describe('when given a proper environmental data payload including custom data', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -148,7 +148,7 @@ describe('HostToClient', () => {
         testResult = validate(testMessage);
       });
       it('should return the validated message', () => {
-        expect(testResult).toEqual(applyProtocol(testMessage));
+        expect(testResult).toEqual(applyClientProtocol(testMessage));
       });
     });
 

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -90,7 +90,8 @@ describe('HostToClient', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: HostToClient;

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -150,7 +150,8 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown'
+          version: 'unknown',
+          direction: 'HostToClient'
         },
         'http://example.com:4040'
       );
@@ -175,7 +176,8 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown'
+          version: 'unknown',
+          direction: 'HostToClient'
         },
         'http://test.example.com'
       );
@@ -194,7 +196,8 @@ describe('FrameManager', () => {
           msg: {
             topic: 'test.topic',
             payload: {}
-          }
+          },
+          direction: 'ClientToHost'
         }
       };
       frameManager.startMessageHandler();
@@ -209,12 +212,48 @@ describe('FrameManager', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: 'ClientToHost'
+      });
+    });
+
+    it('if the messages are sent correctly to a host', () => {
+      mocks.window.raise('message', mocks.messageEvent);
+      expect(mocks.handler).toHaveBeenCalledWith({
+        msgType: mocks.messageEvent.data.msgType,
+        msg: {
+          ...mocks.messageEvent.data.msg,
+          clientId: undefined
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown',
+        direction: 'ClientToHost'
+      });
+    });
+
+    it('if the messages are sent correctly to a host and missing direction', () => {
+      mocks.messageEvent.data.direction = undefined;
+      mocks.window.raise('message', mocks.messageEvent);
+      expect(mocks.handler).toHaveBeenCalledWith({
+        msgType: mocks.messageEvent.data.msgType,
+        msg: {
+          ...mocks.messageEvent.data.msg,
+          clientId: undefined
+        },
+        protocol: 'iframe-coordinator',
+        version: 'unknown',
+        direction: undefined
       });
     });
 
     it('which are blocked if sent from an unexpected origin', () => {
       mocks.messageEvent.origin = 'http://evil.com';
+      mocks.window.raise('message', mocks.messageEvent);
+      expect(mocks.handler).not.toHaveBeenCalled();
+    });
+
+    it('which are blocked if intended for a client', () => {
+      mocks.messageEvent.data.direction = 'HostToClient';
       mocks.window.raise('message', mocks.messageEvent);
       expect(mocks.handler).not.toHaveBeenCalled();
     });
@@ -278,7 +317,8 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown'
+          version: 'unknown',
+          direction: 'HostToClient'
         },
         'http://example.com'
       );

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -1,6 +1,9 @@
 import FrameManager from '../FrameManager';
 import { API_PROTOCOL } from '../messages/LabeledMsg';
 
+// tslint:disable-next-line:no-var-requires
+const version = require('../../package.json').version;
+
 describe('FrameManager', () => {
   let mocks: any;
   let frameManager: FrameManager;
@@ -150,7 +153,7 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown',
+          version,
           direction: 'HostToClient'
         },
         'http://example.com:4040'
@@ -176,7 +179,7 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown',
+          version,
           direction: 'HostToClient'
         },
         'http://test.example.com'
@@ -197,6 +200,7 @@ describe('FrameManager', () => {
             topic: 'test.topic',
             payload: {}
           },
+          version,
           direction: 'ClientToHost'
         }
       };
@@ -212,7 +216,7 @@ describe('FrameManager', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown',
+        version,
         direction: 'ClientToHost'
       });
     });
@@ -226,7 +230,7 @@ describe('FrameManager', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown',
+        version,
         direction: 'ClientToHost'
       });
     });
@@ -241,7 +245,7 @@ describe('FrameManager', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown',
+        version,
         direction: undefined
       });
     });
@@ -317,7 +321,7 @@ describe('FrameManager', () => {
             clientId: undefined
           },
           protocol: 'iframe-coordinator',
-          version: 'unknown',
+          version,
           direction: 'HostToClient'
         },
         'http://example.com'

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -1,19 +1,12 @@
 import { Client } from '../client';
 import {
   API_PROTOCOL,
-  applyProtocol,
+  applyClientProtocol,
   LabeledMsg,
   PartialMsg
 } from '../messages/LabeledMsg';
 import { EnvData, SetupData } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
-
-/** Mark the message as ClientToHost */
-function applyClientToHostProtocol<T, V>(
-  partialMsg: PartialMsg<T, V>
-): LabeledMsg<T, V> {
-  return { ...applyProtocol(partialMsg), direction: 'ClientToHost' };
-}
 
 describe('client', () => {
   let client: any;
@@ -49,7 +42,7 @@ describe('client', () => {
 
     it('should send a client_started notification', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyClientToHostProtocol({
+        applyClientProtocol({
           msgType: 'client_started',
           msg: undefined
         }),
@@ -121,7 +114,7 @@ describe('client', () => {
 
       it('should send a message to the worker', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyClientToHostProtocol({
+          applyClientProtocol({
             msgType: 'notifyRequest',
             msg: {
               title: undefined,
@@ -145,7 +138,7 @@ describe('client', () => {
 
       it('should send a message to the worker', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyClientToHostProtocol({
+          applyClientProtocol({
             msgType: 'notifyRequest',
             msg: {
               title: 'Test title',
@@ -167,7 +160,7 @@ describe('client', () => {
 
     it('should notify worker of new publication', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyClientToHostProtocol({
+        applyClientProtocol({
           msgType: 'publish',
           msg: {
             topic: 'test.topic',
@@ -367,7 +360,7 @@ describe('client', () => {
 
       it('should publish a key event', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyClientToHostProtocol({
+          applyClientProtocol({
             msgType: 'registeredKeyFired',
             msg: {
               altKey: true,
@@ -393,7 +386,7 @@ describe('client', () => {
 
     it('should notify host of navigation request', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyClientToHostProtocol({
+        applyClientProtocol({
           msgType: 'navRequest',
           msg: { url: 'http://www.example.com/' }
         }),
@@ -420,7 +413,7 @@ describe('client', () => {
 
       it('should notify host of navigation request', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyClientToHostProtocol({
+          applyClientProtocol({
             msgType: 'navRequest',
             msg: { url: 'http://www.example.com/' }
           }),
@@ -454,7 +447,7 @@ describe('client', () => {
         client._clientWindow = mockFrameWindow;
         client.start();
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyClientToHostProtocol({
+          applyClientProtocol({
             msgType: 'client_started',
             msg: undefined
           }),


### PR DESCRIPTION
client to host and host to client messages are marked so that the wrong target does not accept them

can be tested using the following package.json entry (on the Publish branch version because dist files were added) 

`"iframe-coordinator": "git+https://github.com/MikeBlandford/iframe-coordinator.git#nestedIframesPublish"
`