### PR TITLE
feat(messaging): support nested iframes by tagging messages with direction

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,11 @@ import {
   HostToClient,
   validate as validateIncoming
 } from './messages/HostToClient';
-import { API_PROTOCOL, applyProtocol, PartialMsg } from './messages/LabeledMsg';
+import {
+  API_PROTOCOL,
+  applyClientProtocol,
+  PartialMsg
+} from './messages/LabeledMsg';
 import {
   EnvData,
   EnvDataHandler,
@@ -101,6 +105,10 @@ export class Client {
 
   private _onWindowMessage = (event: MessageEvent) => {
     let validated = null;
+
+    if (event.data && event.data.direction === 'ClientToHost') {
+      return;
+    }
 
     try {
       validated = validateIncoming(event.data);
@@ -230,8 +238,9 @@ export class Client {
   }
 
   private _sendToHost<T, V>(partialMsg: PartialMsg<T, V>): void {
-    const message = applyProtocol(partialMsg);
-    let validated = null;
+    const message = applyClientProtocol(partialMsg);
+
+    let validated: ClientToHost;
 
     try {
       validated = validateOutgoing(message);

--- a/src/messages/LabeledMsg.ts
+++ b/src/messages/LabeledMsg.ts
@@ -5,6 +5,7 @@ import {
   hardcoded,
   map,
   object,
+  optional,
   string
 } from 'decoders';
 
@@ -21,6 +22,12 @@ const version = require('../../package.json').version;
 export const API_PROTOCOL = 'iframe-coordinator';
 
 /**
+ * Based on MessageDirection, hosts and clients can ignore messages that are not targeted at them.
+ * @external
+ */
+export type MessageDirection = 'ClientToHost' | 'HostToClient';
+
+/**
  * Labeled message is a general structure
  * used by all coordinated messages between
  * host and client.
@@ -35,6 +42,8 @@ export interface LabeledMsg<T, V> extends PartialMsg<T, V> {
   protocol: 'iframe-coordinator';
   /** library version */
   version: string;
+  /** So that nested iframe-coordinators can ignore messages that don't apply */
+  direction?: MessageDirection;
 }
 
 /**
@@ -50,25 +59,36 @@ export interface PartialMsg<T, V> {
 
 /**
  * Takes an object with a `msgType` and `msg` and applies the appropriate
- * `protocol` and `version` fields for the current version of the library.
+ * `direction`, `protocol` and `version` fields for the current version of the library.
  * @param partialMsg
  * @external
  */
-export function applyProtocol<T, V>(
+export function applyClientProtocol<T, V>(
   partialMsg: PartialMsg<T, V>
 ): LabeledMsg<T, V> {
-  return { ...partialMsg, protocol: API_PROTOCOL, version };
+  return {
+    direction: 'ClientToHost',
+    ...partialMsg,
+    protocol: API_PROTOCOL,
+    version
+  };
 }
 
 /**
- * Converts a PartialMsg decoder into a LabeledMsg decoder
- * @param msgDecoder
+ * Takes an object with a `msgType` and `msg` and applies the appropriate
+ * `direction`, `protocol` and `version` fields for the current version of the library.
+ * @param partialMsg
  * @external
  */
-export function labeledDecoder2<T, V>(
-  msgDecoder: Decoder<PartialMsg<T, V>>
-): Decoder<LabeledMsg<T, V>> {
-  return map(msgDecoder, applyProtocol);
+export function applyHostProtocol<T, V>(
+  partialMsg: PartialMsg<T, V>
+): LabeledMsg<T, V> {
+  return {
+    direction: 'HostToClient',
+    ...partialMsg,
+    protocol: API_PROTOCOL,
+    version
+  };
 }
 
 /**
@@ -81,13 +101,19 @@ export function labeledDecoder<T, V>(
   msgDecoder: Decoder<V>
 ): Decoder<LabeledMsg<T, V>> {
   return object({
-    // TODO: in 4.0.0 make protocol and verison fields mandatory
+    // TODO: in 4.0.0 make protocol and version fields mandatory
     protocol: either(
       constant<'iframe-coordinator'>(API_PROTOCOL),
       hardcoded<'iframe-coordinator'>(API_PROTOCOL)
     ),
     version: either(string, hardcoded('unknown')),
     msgType: typeDecoder,
-    msg: msgDecoder
+    msg: msgDecoder,
+    direction: optional(directionDecoder)
   });
 }
+
+const directionDecoder: Decoder<MessageDirection, unknown> = either(
+  constant('ClientToHost'),
+  constant('HostToClient')
+);

--- a/src/messages/Lifecycle.ts
+++ b/src/messages/Lifecycle.ts
@@ -8,7 +8,7 @@ import {
   optional,
   string
 } from 'decoders';
-import { applyProtocol, labeledDecoder, LabeledMsg } from './LabeledMsg';
+import { applyClientProtocol, labeledDecoder, LabeledMsg } from './LabeledMsg';
 
 /**
  * Client started indication.  The client will
@@ -118,7 +118,7 @@ export class Lifecycle {
    * A {@link LabeledStarted} message to send to the host application.
    */
   public static get startedMessage(): LabeledStarted {
-    return applyProtocol({
+    return applyClientProtocol({
       msgType: 'client_started',
       msg: undefined
     });

--- a/src/messages/specs/ClientToHost.spec.ts
+++ b/src/messages/specs/ClientToHost.spec.ts
@@ -35,7 +35,8 @@ describe('ClientToHost', () => {
       const expectedMessage = withClientId({
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       }) as LabeledPublication;
 
       let testResult: ClientToHost;
@@ -60,7 +61,8 @@ describe('ClientToHost', () => {
       const expectedMessage = withClientId({
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       });
 
       let testResult: ClientToHost;
@@ -103,7 +105,8 @@ describe('ClientToHost', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as ClientToHost;
 
       let testResult: ClientToHost;
@@ -134,7 +137,8 @@ describe('ClientToHost', () => {
           custom: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: ClientToHost;
@@ -164,7 +168,8 @@ describe('ClientToHost', () => {
           custom: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: ClientToHost;
@@ -190,7 +195,8 @@ describe('ClientToHost', () => {
       const expectedMessage: ClientToHost = {
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNotification;
 
       let testResult: ClientToHost;
@@ -233,7 +239,8 @@ describe('ClientToHost', () => {
         ...toastMessage,
         msgType: 'notifyRequest',
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNotification;
 
       expect(validate(toastMessage)).toEqual(expectedMessage);
@@ -252,7 +259,8 @@ describe('ClientToHost', () => {
       const expectedMessage = {
         ...testMessage,
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       } as LabeledNavRequest;
 
       let testResult: ClientToHost;

--- a/src/messages/specs/HostToClient.spec.ts
+++ b/src/messages/specs/HostToClient.spec.ts
@@ -1,5 +1,5 @@
 import { HostToClient, validate } from '../HostToClient';
-import { applyProtocol } from '../LabeledMsg';
+import { applyClientProtocol } from '../LabeledMsg';
 
 describe('HostToClient', () => {
   describe('validating an invalid message type', () => {
@@ -17,7 +17,7 @@ describe('HostToClient', () => {
 
   describe('validating publish type', () => {
     describe('when payload is a string', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
@@ -30,7 +30,7 @@ describe('HostToClient', () => {
       });
       it('should return the validated message', () => {
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'publish',
             msg: { ...testMessage.msg, clientId: undefined }
           })
@@ -39,7 +39,7 @@ describe('HostToClient', () => {
     });
 
     describe('when payload is an object', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'publish',
         msg: {
           topic: 'test.topic',
@@ -52,7 +52,7 @@ describe('HostToClient', () => {
       });
       it('should return the validated message', () => {
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'publish',
             msg: { ...testMessage.msg, clientId: undefined }
           })
@@ -90,7 +90,8 @@ describe('HostToClient', () => {
           clientId: undefined
         },
         protocol: 'iframe-coordinator',
-        version: 'unknown'
+        version: 'unknown',
+        direction: undefined
       };
 
       let testResult: HostToClient;
@@ -105,7 +106,7 @@ describe('HostToClient', () => {
 
   describe('validating env_init type', () => {
     describe('when given a proper environmental data payload', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -118,7 +119,7 @@ describe('HostToClient', () => {
       it('should return the validated message', () => {
         const testResult = validate(testMessage);
         expect(testResult).toEqual(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'env_init',
             msg: {
               ...testMessage.msg,
@@ -130,7 +131,7 @@ describe('HostToClient', () => {
     });
 
     describe('when given a proper environmental data payload including custom data', () => {
-      const testMessage: HostToClient = applyProtocol({
+      const testMessage: HostToClient = applyClientProtocol({
         msgType: 'env_init',
         msg: {
           locale: 'nl-NL',
@@ -147,7 +148,7 @@ describe('HostToClient', () => {
         testResult = validate(testMessage);
       });
       it('should return the validated message', () => {
-        expect(testResult).toEqual(applyProtocol(testMessage));
+        expect(testResult).toEqual(applyClientProtocol(testMessage));
       });
     });
 

--- a/src/specs/client.spec.ts
+++ b/src/specs/client.spec.ts
@@ -1,5 +1,10 @@
 import { Client } from '../client';
-import { API_PROTOCOL, applyProtocol } from '../messages/LabeledMsg';
+import {
+  API_PROTOCOL,
+  applyClientProtocol,
+  LabeledMsg,
+  PartialMsg
+} from '../messages/LabeledMsg';
 import { EnvData, SetupData } from '../messages/Lifecycle';
 import { Publication } from '../messages/Publication';
 
@@ -37,7 +42,7 @@ describe('client', () => {
 
     it('should send a client_started notification', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyProtocol({
+        applyClientProtocol({
           msgType: 'client_started',
           msg: undefined
         }),
@@ -109,7 +114,7 @@ describe('client', () => {
 
       it('should send a message to the worker', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'notifyRequest',
             msg: {
               title: undefined,
@@ -133,7 +138,7 @@ describe('client', () => {
 
       it('should send a message to the worker', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'notifyRequest',
             msg: {
               title: 'Test title',
@@ -155,7 +160,7 @@ describe('client', () => {
 
     it('should notify worker of new publication', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyProtocol({
+        applyClientProtocol({
           msgType: 'publish',
           msg: {
             topic: 'test.topic',
@@ -168,14 +173,34 @@ describe('client', () => {
     });
   });
 
-  describe('when recieving an invalid window message from the host application', () => {
+  describe('when listening for messages from the host application', () => {
     let subscriptionCalled = false;
     beforeEach(() => {
+      subscriptionCalled = false;
       client.start();
       client.messaging.addListener('origin', () => (subscriptionCalled = true));
     });
 
-    it('should throw an exception if it is an iframe-coordinator message', () => {
+    it('should throw an exception on invalid iframe-coordinator message', () => {
+      expect(() => {
+        mockFrameWindow.trigger('message', {
+          origin: 'origin',
+          data: {
+            protocol: API_PROTOCOL,
+            msgType: 'test data',
+            msg: 'msg',
+            direction: 'HostToClient'
+          }
+        });
+      }).toThrowMatching(err => {
+        return err.message.startsWith(
+          'I recieved an invalid message from the host application'
+        );
+      });
+      expect(subscriptionCalled).toBe(false);
+    });
+
+    it('should throw an exception on invalid iframe-coordinator message with no direction', () => {
       expect(() => {
         mockFrameWindow.trigger('message', {
           origin: 'origin',
@@ -190,9 +215,10 @@ describe('client', () => {
           'I recieved an invalid message from the host application'
         );
       });
+      expect(subscriptionCalled).toBe(false);
     });
 
-    it('should not throw an exception if it is not labeled as being from iframe-coordinator', () => {
+    it('should not throw an exception if not from iframe-coordinator', () => {
       expect(() => {
         mockFrameWindow.trigger('message', {
           protocol: 'whatev',
@@ -204,6 +230,50 @@ describe('client', () => {
           }
         });
       }).not.toThrow();
+      expect(subscriptionCalled).toBe(false);
+    });
+
+    it('should ignore messages from client applications', () => {
+      expect(() => {
+        mockFrameWindow.trigger('message', {
+          protocol: API_PROTOCOL,
+          origin: 'origin',
+          data: {
+            protocol: API_PROTOCOL,
+            msgType: 'invalid message type',
+            msg: 'msg',
+            direction: 'ClientToHost'
+          }
+        });
+      }).not.toThrow();
+      expect(subscriptionCalled).toBe(false);
+    });
+  });
+
+  describe('when recieving an valid window message from the host application missing the direction field', () => {
+    let publishCalls = 0;
+    let recievedPayload: string;
+    beforeEach(() => {
+      client.start();
+      client.messaging.addListener('test.topic', (data: Publication) => {
+        publishCalls++;
+        recievedPayload = data.payload;
+      });
+      mockFrameWindow.trigger('message', {
+        origin: 'origin',
+        data: {
+          msgType: 'publish',
+          msg: {
+            topic: 'test.topic',
+            payload: 'test data'
+          }
+        }
+      });
+    });
+
+    it('should raise a publish event for the topic', () => {
+      expect(publishCalls).toBe(1);
+      expect(recievedPayload).toBe('test data');
     });
   });
 
@@ -223,7 +293,8 @@ describe('client', () => {
           msg: {
             topic: 'test.topic',
             payload: 'test data'
-          }
+          },
+          direction: 'HostToClient'
         }
       });
     });
@@ -289,7 +360,7 @@ describe('client', () => {
 
       it('should publish a key event', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'registeredKeyFired',
             msg: {
               altKey: true,
@@ -315,7 +386,7 @@ describe('client', () => {
 
     it('should notify host of navigation request', () => {
       expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-        applyProtocol({
+        applyClientProtocol({
           msgType: 'navRequest',
           msg: { url: 'http://www.example.com/' }
         }),
@@ -342,7 +413,7 @@ describe('client', () => {
 
       it('should notify host of navigation request', () => {
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'navRequest',
             msg: { url: 'http://www.example.com/' }
           }),
@@ -376,7 +447,7 @@ describe('client', () => {
         client._clientWindow = mockFrameWindow;
         client.start();
         expect(mockFrameWindow.parent.postMessage).toHaveBeenCalledWith(
-          applyProtocol({
+          applyClientProtocol({
             msgType: 'client_started',
             msg: undefined
           }),


### PR DESCRIPTION
Cross-frame messages are now tagged as `HostToClient` or `ClientToHost` so that a frame running both
host and client code will not try to incorrectly process messages intended for the host code with
the client code and vice-versa.