### PR TITLE
fix(cli): missing hash and query parameters

### DIFF
--- a/cli/embedded-app/src/router.ts
+++ b/cli/embedded-app/src/router.ts
@@ -7,9 +7,11 @@ Vue.use(Router);
 export default new Router({
   routes: [
     {
-      path: '/*',
+      path: '*',
       component: IframeEmbed,
-      props: true
+      props: router => ({
+        frameRoute: router.fullPath
+      })
     }
   ]
 });

--- a/cli/embedded-app/src/views/IframeEmbed.vue
+++ b/cli/embedded-app/src/views/IframeEmbed.vue
@@ -37,19 +37,13 @@
 <script>
 export default {
   name: 'iframeEmbed',
-  props: ['pathMatch'],
+  props: ['frameRoute'],
   data() {
     return {
       frameUrl: '',
       showMenu: true,
       clientConfig: {}
     };
-  },
-  computed: {
-    frameRoute() {
-      // Ensure route is valid when the matched path is '';
-      return '/' + this.pathMatch;
-    }
   },
   methods: {
     displayToast(event) {


### PR DESCRIPTION
`pathMatch` would exclude the hash and query values. So instead use `fullPath` as the value for `frameRoute`.