### PR TITLE
fix(framemanager): COMUI-460 - Added new default to sandbox attributes

### DIFF
--- a/src/FrameManager.ts
+++ b/src/FrameManager.ts
@@ -21,6 +21,7 @@ frame-router iframe {
 
 /** @internal default iframe sandbox attributes */
 const DEFAULT_SANDBOX = [
+  'allow-popups-to-escape-sandbox',
   'allow-scripts',
   'allow-same-origin',
   'allow-modals',

--- a/src/specs/FrameManager.spec.ts
+++ b/src/specs/FrameManager.spec.ts
@@ -78,7 +78,7 @@ describe('FrameManager', () => {
     expect(mocks.document.createElement).toHaveBeenCalledWith('iframe');
     expect(mocks.frame.setAttribute).toHaveBeenCalledWith(
       'sandbox',
-      'allow-scripts allow-same-origin allow-modals allow-forms allow-popups allow-downloads'
+      'allow-popups-to-escape-sandbox allow-scripts allow-same-origin allow-modals allow-forms allow-popups allow-downloads'
     );
   });
 


### PR DESCRIPTION
Fix for https://inindca.atlassian.net/browse/COMUI-460

As suspected by @MattCheely adding the APTES attribute to the list of defaults made this work.

Tested via local build npm linked to web-directory, then opened Coaching in a version prior to the "download pdf" change.