### PR TITLE
fix(docs): fix static asset URLs in deployed docs

### DIFF
--- a/scripts/prepare-docs
+++ b/scripts/prepare-docs
@@ -6,7 +6,7 @@ const glob = require('glob');
 const path = require('path');
 const url = require('url');
 
-const docPath = path.join(__dirname, '../doc');
+const docPath = path.join(__dirname, '../dist/docs');
 
 main();
 


### PR DESCRIPTION
I missed this path change in the previous docs update.