### PR TITLE
fix(cli): add missing example file to package, improve behavior when proxied

### DIFF
--- a/cli/embedded-app/vue.config.js
+++ b/cli/embedded-app/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  publicPath: ''
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dist/es5/index.js",
     "dist/**/*.d.ts",
     "cli/ifc-cli.js",
+    "cli/example-ifc.config.js",
     "cli/embedded-app/dist/**/*"
   ],
   "main": "dist/index.js",


### PR DESCRIPTION
The CLI's `help` action tries to print an example configuration file, but that file wasn't getting
included in the NPM package, so it would just error out. That file has been added to the includes in
package.json.  Additionally, the js and css asset references for the CLI embedded application have
been moved to relative paths so that the app still works correctly if proxied under a non-root path
on a domain. This can help when integrating the cli with other application build tools.