### PR TITLE
feat(ifc-cli): allow consumer to specify their own ssl cert and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Options:
   -f, --config-file <file>  iframe client configuration file (default: "/home/mcheely/projects/iframe-coordinator/ifc-cli.config.js")
   -p, --port <port_num>     port number to host on (default: 3000)
   -s, --ssl                 serve over https
+  --ssl-cert <cert_path>    certificate file to use for https
+  --ssl-key <key_path>      key file to use for https
   -h, --help                output usage information
 
   This program will start a server for a basic iframe-coordinator host app. In

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "format.fix": "prettier --fix **/*.ts **/*.tsx",
     "lint.fix": "npm run lint.ts -- --fix",
     "lint.format": "prettier --check **/*.ts **/*.tsx",
-    "lint.commit": "commitlint -f e307dddc51545900940861f06baf210cd4a79cec",
+    "lint.commit": "commitlint -f de759fc509cf39895450dc31742cfb36b08e01b8",
     "lint": "tslint --project tsconfig.json && npm run lint.format && npm run lint.commit",
     "prepare": "./scripts/prepare-deps.sh",
     "release": "standard-version",


### PR DESCRIPTION
Instead of solely relying on devCertAuthority for certificates when using the --ssl option, allow
the consumer to specify their own ssl cert and key. If either of the two do not exist, then
devCertAuthority will be used.

COMUI-1082