### PR TITLE
fix(url-utils): joinRoutes now accounts for routes that normalize to …

### DIFF
--- a/src/specs/urlUtils.spec.ts
+++ b/src/specs/urlUtils.spec.ts
@@ -1,0 +1,28 @@
+import {
+  joinRoutes,
+  normalizeRoute,
+  stripLeadingSlash,
+  stripLeadingSlashAndHashTag,
+  stripTrailingSlash
+} from '../urlUtils';
+
+describe('urlUtils', () => {
+  describe('joinRoutes', () => {
+    [
+      { input: ['', '', ''], expectedOutput: '' },
+      { input: ['test', 'test', 'test'], expectedOutput: 'test/test/test' },
+      {
+        input: ['/test/', '/test/', '/test/'],
+        expectedOutput: 'test/test/test'
+      },
+      { input: ['test', '', 'test'], expectedOutput: 'test/test' },
+      { input: ['/test/', '', '/test/'], expectedOutput: 'test/test' },
+      { input: ['test', '/', 'test'], expectedOutput: 'test/test' },
+      { input: ['/test/', '/', '/test/'], expectedOutput: 'test/test' }
+    ].forEach(({ input, expectedOutput }, index) => {
+      it(`should work as expected (${index + 1})`, () => {
+        expect(joinRoutes(...input)).toBe(expectedOutput);
+      });
+    });
+  });
+});

--- a/src/urlUtils.ts
+++ b/src/urlUtils.ts
@@ -36,5 +36,15 @@ export function stripLeadingSlashAndHashTag(str: string): string {
  *
  */
 export function joinRoutes(...routes: string[]): string {
-  return routes.map(route => normalizeRoute(route)).join('/');
+  return routes
+    .reduce((acc, route) => {
+      const normalizedRoute = normalizeRoute(route);
+
+      if (normalizedRoute) {
+        return acc.concat([normalizedRoute]);
+      }
+
+      return acc;
+    }, [] as string[])
+    .join('/');
 }


### PR DESCRIPTION
…an empty string

joinRoutes now accounts for routes that normalize to an empty string

COMUI-1131