### PR TITLE
Fix jenkins build

### DIFF
--- a/packages/iframe-coordinator/rollup.config.js
+++ b/packages/iframe-coordinator/rollup.config.js
@@ -1,6 +1,9 @@
 import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
-import pkg from './package.json' assert { type: 'json' };
+import fs from 'fs';
+
+const packageVersion = JSON.parse(fs.readFileSync('package.json').toString())
+  .version;
 
 export default [
   {
@@ -9,9 +12,12 @@ export default [
       file: 'dist/index.js',
       format: 'es'
     },
-    plugins: [typescript(), replace({
-      __PACKAGE_VERSION__: pkg.version
-    })]
+    plugins: [
+      typescript(),
+      replace({
+        __PACKAGE_VERSION__: packageVersion
+      })
+    ]
   },
   {
     input: 'src/client.ts',
@@ -19,9 +25,12 @@ export default [
       file: 'dist/client.js',
       format: 'es'
     },
-    plugins: [typescript(), replace({
-      __PACKAGE_VERSION__: pkg.version
-    })]
+    plugins: [
+      typescript(),
+      replace({
+        __PACKAGE_VERSION__: packageVersion
+      })
+    ]
   },
   {
     input: 'src/host.ts',
@@ -29,8 +38,11 @@ export default [
       file: 'dist/host.js',
       format: 'es'
     },
-    plugins: [typescript(), replace({
-      __PACKAGE_VERSION__: pkg.version
-    })]
+    plugins: [
+      typescript(),
+      replace({
+        __PACKAGE_VERSION__: packageVersion
+      })
+    ]
   }
 ];

--- a/packages/iframe-coordinator/tsconfig.json
+++ b/packages/iframe-coordinator/tsconfig.json
@@ -4,6 +4,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "module": "ESNext",
+    "moduleResolution": "node",
     "declaration": true,
     "declarationDir": "./dist",
     "target": "ES2015"


### PR DESCRIPTION
Of course there were a couple of problems with the rollup updated that didn't manifest until the first build.

- The way I imported `package.json` in the rollup config didn't work in older versions of node 16 on the CI server
- I forgot to test the docs build locally