### PR TITLE
feat(frame-router): emit custom dom event for client publish messages

### DIFF
--- a/packages/iframe-coordinator/src/elements/frame-router.ts
+++ b/packages/iframe-coordinator/src/elements/frame-router.ts
@@ -196,6 +196,7 @@ export default class FrameRouterElement extends HTMLElement {
         const publication: Publication = message.msg;
         publication.clientId = this._currentClientId;
         this._publishEmitter.dispatch(message.msg.topic, publication);
+        this._dispatchClientMessage(message);
         break;
       case 'client_started':
         this._handleLifecycleMessage(message);


### PR DESCRIPTION
COMUI-1495

Add DOM event for `publish` message using the same format as all other client messages (except `client_started`) as an alternative to attaching listeners directly to the `messaging` emitter.