### PR TITLE
fix(frame-router): queue events until component is connected

### DIFF
--- a/packages/iframe-coordinator/src/elements/frame-router.ts
+++ b/packages/iframe-coordinator/src/elements/frame-router.ts
@@ -256,7 +256,7 @@ export default class FrameRouterElement extends HTMLElement {
 
   private _emitQueuedEvents() {
     if (this.isConnected) {
-      this._queuedEvents.map(event => this.dispatchEvent(event));
+      this._queuedEvents.forEach(event => this.dispatchEvent(event));
       this._queuedEvents = [];
     }
   }


### PR DESCRIPTION
COMUI-1648

When properties and attributes are set in a virtual DOM, the resulting frame-router events currently fire into the void. This PR adds a check to ensure the component is connected to the DOM or queues the events for when the component becomes connected.