### PR TITLE
fix: merge query for no-hash routes

### DIFF
--- a/packages/iframe-coordinator/src/HostRouter.ts
+++ b/packages/iframe-coordinator/src/HostRouter.ts
@@ -179,10 +179,18 @@ function applyRoute(urlStr: string, route: string): string {
   const newUrl = new URL(urlStr, window.location.href);
   if (newUrl.hash) {
     const baseClientRoute = stripTrailingSlash(newUrl.hash);
+    // This supports non-standard query params in hash route directly
     newUrl.hash = `${baseClientRoute}/${route}`;
   } else {
     const baseClientPath = stripTrailingSlash(newUrl.pathname);
-    newUrl.pathname = `${baseClientPath}/${route}`;
+    // Here, we merge host query params and route query params
+    const routeUrl = new URL(route, window.location.href);
+    newUrl.pathname = `${baseClientPath}${routeUrl.pathname}`;
+    const query = new URLSearchParams(newUrl.search);
+    for (const [key, value] of routeUrl.searchParams) {
+      query.set(key, value);
+    }
+    newUrl.search = query.toString();
   }
   return newUrl.toString();
 }

--- a/packages/iframe-coordinator/src/specs/HostRouter.spec.ts
+++ b/packages/iframe-coordinator/src/specs/HostRouter.spec.ts
@@ -17,6 +17,14 @@ describe("HostRouter", () => {
         url: "http://example.com/my/pushstate/app/?query=works",
         assignedRoute: "noHash",
       },
+      noClientHashNoQuery: {
+        url: "http://example.com/my/pushstate/app/noquery/",
+        assignedRoute: "noHash/noQuery",
+      },
+      noClientHashMergeQuery: {
+        url: "http://example.com/my/pushstate/app/mergequery/?alpha=true",
+        assignedRoute: "noHash/mergeQuery",
+      },
       withSandboxAndAllow: {
         url: clientUrl,
         assignedRoute: "route/two",
@@ -83,6 +91,34 @@ describe("HostRouter", () => {
         "http://example.com/my/pushstate/app/foo/bar?query=works",
       );
       expect(clientInfo.id).toBe("noClientHash");
+    });
+
+    it("should append to the path when the client url has no hash and no query", () => {
+      const clientInfo = hostRouter.getClientTarget(
+        "noHash/noQuery/foo/bar?query=works",
+      );
+      if (!clientInfo) {
+        fail();
+        return;
+      }
+      expect(clientInfo.url).toBe(
+        "http://example.com/my/pushstate/app/noquery/foo/bar?query=works",
+      );
+      expect(clientInfo.id).toBe("noClientHashNoQuery");
+    });
+
+    it("should append to the path when the client url has no hash and merging query", () => {
+      const clientInfo = hostRouter.getClientTarget(
+        "noHash/mergeQuery/foo/bar?beta=true",
+      );
+      if (!clientInfo) {
+        fail();
+        return;
+      }
+      expect(clientInfo.url).toBe(
+        "http://example.com/my/pushstate/app/mergequery/foo/bar?alpha=true&beta=true",
+      );
+      expect(clientInfo.id).toBe("noClientHashMergeQuery");
     });
 
     it('should return "allow" and "sandbox" config options if they exist', () => {


### PR DESCRIPTION
Hello there :)

I wanted to propose a fix for a particular use-case with client routes.

What I found is that when using hash router, everything works fine when specifying query in `route` attribute, though if the client has standard routing, then query params are encoded in pathname, breaking the iframe url.

The proposal here would be to merge query params both from host, and specified route, and then assign `pathname` and `search` with the computed values.

I also added two tests but would be happy to discuss about it if you feel that should not be a supported use-case.