### PR TITLE
fix(frame-router): fix specificity bug in route matching

### DIFF
--- a/packages/iframe-coordinator/src/HostRouter.ts
+++ b/packages/iframe-coordinator/src/HostRouter.ts
@@ -18,7 +18,7 @@ export class HostRouter {
         return parseRegistration(id, data);
       })
       // Sorts by most path segments in url descending to make sure more specific paths are matched first
-      .sort(byMostPathSegments);
+      .sort(byPathSpecificity);
   }
 
   /**
@@ -188,8 +188,20 @@ function applyRoute(urlStr: string, route: string): string {
 }
 
 /**
- * Helper function for sorting clients by length of url path segments descending
+ * Helper function for sorting clients by url path specificity, from most to
+ * least specific
  */
-function byMostPathSegments(a: ClientInfo, b: ClientInfo): number {
-  return b.assignedRoute.split("/").length - a.assignedRoute.split("/").length;
+function byPathSpecificity(a: ClientInfo, b: ClientInfo): number {
+  const aPathLength = a.assignedRoute.split("/").length;
+  const bPathLength = b.assignedRoute.split("/").length;
+  const pathDiff = bPathLength - aPathLength;
+  if (pathDiff !== 0) {
+    // The longer path is more specific and should come first
+    return pathDiff;
+  } else {
+    // If the path has the same number of segments, putting the longer
+    // string length first ensures more-specific paths are matched first.
+    // e.g. /foo/barbaz comes before /foo/bar
+    return b.assignedRoute.length - a.assignedRoute.length;
+  }
 }

--- a/packages/iframe-coordinator/src/specs/HostRouter.spec.ts
+++ b/packages/iframe-coordinator/src/specs/HostRouter.spec.ts
@@ -108,5 +108,37 @@ describe("HostRouter", () => {
       );
       expect(clientInfo.id).toBe("withMoreSpecificity");
     });
+
+    it("should resolve same-prefix routes by specificity regardless of order", () => {
+      hostRouter = new HostRouter({
+        lessSpecific: {
+          assignedRoute: "assigned/route/",
+          url: "about:blank",
+        },
+        moreSpecific: {
+          assignedRoute: "assigned/route-modified/",
+          url: "about:blank",
+        },
+      });
+      let clientInfo = hostRouter.getClientTarget(
+        "assigned/route-modified/sub-route",
+      );
+      expect(clientInfo?.id).toBe("moreSpecific");
+
+      hostRouter = new HostRouter({
+        moreSpecific: {
+          assignedRoute: "assigned/route-modified/",
+          url: "about:blank",
+        },
+        lessSpecific: {
+          assignedRoute: "assigned/route/",
+          url: "about:blank",
+        },
+      });
+      clientInfo = hostRouter.getClientTarget(
+        "assigned/route-modified/sub-route",
+      );
+      expect(clientInfo?.id).toBe("moreSpecific");
+    });
   });
 });


### PR DESCRIPTION
A previous attempt at fixing route specificity fixed the specific issue it was meant to address, but inadvertantly created a different source of ambiguity. This change introduces additional route sorting to resolve the issue.

COMUI-4239