### PR TITLE
chore(ifc-cli): remove unnecessary explicit iframe-coordinator dependency

### DIFF
--- a/packages/iframe-coordinator-cli/package.json
+++ b/packages/iframe-coordinator-cli/package.json
@@ -10,7 +10,6 @@
     "express": "^4.21.1",
     "find-root": "^1.1.0",
     "http-proxy-middleware": "^3.0.3",
-    "iframe-coordinator": "6.3.4",
     "vue": "^2.7.16",
     "vue-class-component": "^7.2.6",
     "vue-notification": "^1.3.20",


### PR DESCRIPTION
NPM will automatically pick up iframe-coordinator from the local workspace. That version gets bundled by vite/rollup when generating the package, so the dependency isn't needed at runtime either.